### PR TITLE
Link AWS Client VPN on/off CloudFormation template; mention stack tag privs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Lifecycle Manager, or Systems Manager existed. It still has advantages:
 
 ## Tag Keys (Operations)
 
-|`sched-` + ...|`-stop` `-start`|`-hibernate` `-start`|`-backup`|`-reboot-backup`|`-reboot`|`-reboot-failover`|`-set-Enable-false` `-set-Enable-true`|
+|`sched‑`&nbsp;+&nbsp;&hellip;|`‑stop` `‑start`|`‑hibernate` `‑start`|`‑backup`|`‑reboot‑backup`|`‑reboot`|`‑reboot‑failover`|`‑set‑Enable‑false` `‑set‑Enable‑true`|
 |--|--|--|--|--|--|--|--|
 |[EC2 instance](https://console.aws.amazon.com/ec2/v2/home#Instances)|&check;|&check;|image (AMI)|image (AMI)|&check;|||
 |[EBS volume](https://console.aws.amazon.com/ec2/v2/home#Volumes)|||snapshot|||||
@@ -98,6 +98,8 @@ Lifecycle Manager, or Systems Manager existed. It still has advantages:
 |[RDS database cluster](https://console.aws.amazon.com/rds/home#databases:)|&check;||cluster snapshot||&check;||
 |[CloudFormation stack](https://console.aws.amazon.com/cloudformation/home#/stacks)|||||||&check;|
 
+* Do not copy and paste from this table to AWS; tag keys in the table contain
+  non-breaking (non-ASCII) hyphens!
 * Not all EC2 instances support hibernation.
 * Not all RDS database clusters support cluster-level reboot.
 * If an AWS resource is tagged for multiple operations at the same time, an

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Lifecycle Manager, or Systems Manager existed. It still has advantages:
 
 ## Tag Keys (Operations)
 
-||`sched‑stop` `sched‑start`|`sched‑hibernate` `sched‑start`|`sched‑backup`|`sched‑reboot‑backup`|`sched‑reboot`|`sched‑reboot‑failover`|`sched‑set‑Enable‑false` `sched‑set‑Enable‑true`|
+|`sched-` + ...|`-stop` `-start`|`-hibernate` `-start`|`-backup`|`-reboot-backup`|`-reboot`|`-reboot-failover`|`-set-Enable-false` `-set-Enable-true`|
 |--|--|--|--|--|--|--|--|
 |[EC2 instance](https://console.aws.amazon.com/ec2/v2/home#Instances)|&check;|&check;|image (AMI)|image (AMI)|&check;|||
 |[EBS volume](https://console.aws.amazon.com/ec2/v2/home#Volumes)|||snapshot|||||
@@ -98,8 +98,6 @@ Lifecycle Manager, or Systems Manager existed. It still has advantages:
 |[RDS database cluster](https://console.aws.amazon.com/rds/home#databases:)|&check;||cluster snapshot||&check;||
 |[CloudFormation stack](https://console.aws.amazon.com/cloudformation/home#/stacks)|||||||&check;|
 
-* Do not copy and paste tag keys from the table to AWS; the ones in the table
-  contain non-breaking (non-ASCII) hyphens.
 * Not all EC2 instances support hibernation.
 * Not all RDS database clusters support cluster-level reboot.
 * If an AWS resource is tagged for multiple operations at the same time, an
@@ -156,7 +154,7 @@ Backup operations create a "child" resource (image or snapshot) from a
 |--|--|--|
 |Prefix|`zsched`|Distinguishes backups created by Lights Off. `z` sorts after most manually-created images and snapshots.|
 |Parent name or identifier|`webserver`|Meaningfully identifies the parent by `Name` tag value; otherwise, indicates the physical identifier. Groups backups of the same parent.|
-|Date and time|`20171231T1400Z`|Groups backups scheduled for the same date and time. `Z` stands for the UTC time zone.|
+|Date and time|`20171231T1400Z`|Groups backups scheduled for the same date and time. `Z` stands for UTC time.|
 |Random suffix|`g3a8a`|Guarantees a unique name.|
 
 * Parts are separated by hyphens (`-`).
@@ -406,12 +404,10 @@ accounts if you want to deploy a CloudFormation StackSet with
 Using tags on your own CloudFormation stack to change a stack parameter on
 schedule is an advanced Lights Off feature.
 
-A sample use case is preserving the free/low-cost resources of an AWS Client
-VPN setup but deleting the `AWS::EC2::ClientVpnTargetNetworkAssociation` at
-the end of the work day. At 10¢ per hour, this saves up to $650 per year.
-(Temporarily opening after-hours VPN access is as simple as manually updating
-the VPN stack or temporarily adding the next multiple of 10 minutes to the VPN
-stack's `sched-set-Enable-true` tag!)
+A sample use case is turning off an AWS Client VPN at the end of the day, when
+no one else will be connecting. See
+[10-minute AWS Client VPN](https://github.com/sqlxpert/10-minute-aws-client-vpn)
+for potential savings of $600 per year.
 
 To make your own CloudFormation template compatible with Lights Off, follow
 the instructions in the sample template,
@@ -442,7 +438,7 @@ supported) required the following additions:
       ("DB", "Cluster", "Snapshot"),
       "Identifier",
       name_chars_max=63,
-      name_chars_unsafe_regexp=r"[^a-zA-Z0-9-]|--",
+      name_chars_unsafe_regexp=r"[^a-zA-Z0-9-]|--+",
       create_kwargs=lambda child_name, child_tags_list: {
         "DBClusterSnapshotIdentifier": child_name,
         "Tags": child_tags_list,

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Lifecycle Manager, or Systems Manager existed. It still has advantages:
 
 ## Tag Keys (Operations)
 
-|`sched‑`&nbsp;+&nbsp;&hellip;|`‑stop` `‑start`|`‑hibernate` `‑start`|`‑backup`|`‑reboot‑backup`|`‑reboot`|`‑reboot‑failover`|`‑set‑Enable‑false` `‑set‑Enable‑true`|
+||`sched‑stop` `sched‑start`|`sched‑hibernate` `sched‑start`|`sched‑backup`|`sched‑reboot‑backup`|`sched‑reboot`|`sched‑reboot‑failover`|`sched‑set‑Enable‑false` `sched‑set‑Enable‑true`|
 |--|--|--|--|--|--|--|--|
 |[EC2 instance](https://console.aws.amazon.com/ec2/v2/home#Instances)|&check;|&check;|image (AMI)|image (AMI)|&check;|||
 |[EBS volume](https://console.aws.amazon.com/ec2/v2/home#Volumes)|||snapshot|||||
@@ -98,8 +98,8 @@ Lifecycle Manager, or Systems Manager existed. It still has advantages:
 |[RDS database cluster](https://console.aws.amazon.com/rds/home#databases:)|&check;||cluster snapshot||&check;||
 |[CloudFormation stack](https://console.aws.amazon.com/cloudformation/home#/stacks)|||||||&check;|
 
-* Do not copy and paste from this table to AWS; tag keys in the table contain
-  non-breaking (non-ASCII) hyphens!
+* Do not copy and paste tag keys from the table to AWS; the table uses
+  non-breaking (non-ASCII) hyphens for formatting purposes.
 * Not all EC2 instances support hibernation.
 * Not all RDS database clusters support cluster-level reboot.
 * If an AWS resource is tagged for multiple operations at the same time, an

--- a/cloudformation/lights_off_aws_cloudformation_ops_example.yaml
+++ b/cloudformation/lights_off_aws_cloudformation_ops_example.yaml
@@ -64,10 +64,10 @@ Resources:
 
   ############################################################################
   # Separately, you must define a service role that allows CloudFormation to
-  # create, update and delete ALL of the resources in your template, and you
-  # MUST select that role when you create a stack from your template.
-  # Otherwise, Lights Off will not be able to update your stack. Test the role
-  # by performing a stack update. See
+  # create, tag, update, untag, and delete ALL of the resources in your
+  # template, and you MUST select that role when you create a stack from your
+  # template. Otherwise, Lights Off will not be able to update your stack.
+  # Test your deployment role by performing a stack update. See
   # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html
   #
   # Before creating a stack from this sample template, create an IAM role.
@@ -78,6 +78,22 @@ Resources:
   #
   # Least-privilege example: DeploymentRole in lights_off_aws_prereq.yaml
   # supports creation of a stack from lights_off_aws.yaml
+  #
+  # Permission to create, modify, and delete arbitrary tags for stack
+  # resources is necessary because CloudFormation automatically propagates
+  # stack-level tags (including the sched-set-Enable-true and -false tags that
+  # you will add) to resources that it creates. If your deployment role does
+  # not allow tagging, then stack updates will fail. Because CloudFormation is
+  # updated regularly to propagate stack tags to more resource types, it is
+  # wise to provide tagging privileges for all resource types in your
+  # template, even if CloudFormation cannot yet tag them. In many cases, you
+  # can achieve least-privilege with a condition key:
+  #
+  # "StringLike": { "aws:ResourceTag/aws:cloudformation:stack-name": "*KEYWORD*" }
+  #
+  # where KEYWORD is some word that you will require in the name of all stacks
+  # created using your deployment role, and that you will not allow in the
+  # names of any other stacks.
   ############################################################################
 
   ConditionalSecGrp:


### PR DESCRIPTION
* No changes to deployables
* Readme: link to my AWS Client VPN CloudFormation template, which works with Lights Off to allow tag-based on/off schedules
* Sample CloudFormation template: mention requirement for resource tagging privileges in deployment role