### PR TITLE
Less need for KMS key policy changes, for sched-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ Despite new features, the code has gotten shorter, based on GitHub LOC.
 |:---:|:---:|:---:|
 |2017| &asymp; 775|&asymp; 2,140|
 |2022|630|800 &check;|
-|2025|530 &check;|820|
+|2025|530 &check;|870|
 
 ## Dedication
 

--- a/cloudformation/lights_off_aws.yaml
+++ b/cloudformation/lights_off_aws.yaml
@@ -116,6 +116,32 @@ Parameters:
       https://aws.amazon.com/about-aws/whats-new/2018/10/aws-lambda-supports-functions-that-can-run-up-to-15-minutes/
     Default: 60
 
+  DoLambdaFnReservedConcurrentExecutions:
+    Type: Number
+    Description: >-
+      How many scheduled operations can be done in parallel. See
+      https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html#configuration-concurrency-reserved
+    MinValue: 0
+    Default: 5
+
+  RequireSameAccountKmsKeyPolicyForEc2StartInstances:
+    Type: String
+    Description: >-
+      When starting an EC2 instance with an EBS volume that is encrypted with
+      a custom KMS key, whether to defer to the key policy even if the custom
+      key and the EC2 instance are in the same AWS account. The default,
+      "false", lets the "Do" AWS Lambda function use any custom key in the
+      same AWS account even if the key policy doesn't explicitly allow it.
+      Changing this to "true" treats same-account custom keys just like
+      other-account custom keys: the "Do" function can only use a key if the
+      key policy allows, and otherwise, the request to start the EC2 instance
+      will fail. For a sample key policy statement, see:
+      https://github.com/sqlxpert/lights-off-aws#starting-ec2-instances-with-encrypted-ebs-volumes
+    Default: "false"
+    AllowedValues:
+      - "false"
+      - "true"
+
   DoLambdaFnRoleAttachLocalPolicyName:
     Type: String
     Description: >-
@@ -127,14 +153,6 @@ Parameters:
       Policies are account-wide, not regional. See
       https://github.com/sqlxpert/lights-off-aws/README.md#security-steps-you-can-take
     Default: ""
-
-  DoLambdaFnReservedConcurrentExecutions:
-    Type: Number
-    Description: >-
-      How many scheduled operations can be done in parallel. See
-      https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html#configuration-concurrency-reserved
-    MinValue: 0
-    Default: 5
 
   DoLambdaFnMemoryMB:
     Type: Number
@@ -268,6 +286,7 @@ Metadata:
           default: AWS Lambda function to do scheduled operations
         Parameters:
           - DoLambdaFnReservedConcurrentExecutions
+          - RequireSameAccountKmsKeyPolicyForEc2StartInstances
           - DoLambdaFnRoleAttachLocalPolicyName
           - DoLambdaFnMemoryMB
           - DoLambdaFnTimeoutSecs
@@ -311,6 +330,8 @@ Metadata:
         default: Seconds before timeout
       DoLambdaFnReservedConcurrentExecutions:
         default: Number of parallel operations
+      RequireSameAccountKmsKeyPolicyForEc2StartInstances:
+        default: Require same-account KMS key policy for EC2 sched-start
       DoLambdaFnRoleAttachLocalPolicyName:
         default: Name of local policy to attach
       DoLambdaFnMemoryMB:
@@ -336,8 +357,8 @@ Conditions:
 
   EnableTrue: !Equals [ !Ref Enable, "true" ]
 
-  DoLambdaFnRoleAttachLocalPolicyNameBlank:
-    !Equals [ !Ref DoLambdaFnRoleAttachLocalPolicyName, "" ]
+  RequireSameAccountKmsKeyPolicyForEc2StartInstancesTrue:
+    !Equals [ !Ref RequireSameAccountKmsKeyPolicyForEc2StartInstances, "true" ]
 
   SqsKmsKeyBlank: !Equals [ !Ref SqsKmsKey, "" ]
 
@@ -345,6 +366,9 @@ Conditions:
     Fn::And:
       - !Not [ !Equals [ !Ref SqsKmsKey, "" ] ]
       - !Not [ !Equals [ !Ref SqsKmsKey, "alias/aws/sqs" ] ]
+
+  DoLambdaFnRoleAttachLocalPolicyNameBlank:
+    !Equals [ !Ref DoLambdaFnRoleAttachLocalPolicyName, "" ]
 
   CloudWatchLogsKmsKeyBlank: !Equals [ !Ref CloudWatchLogsKmsKey, "" ]
 
@@ -556,6 +580,36 @@ Resources:
                   - ec2:DeregisterImage
                   - ec2:DeleteSnapshot
                 Resource: "*"
+
+        - Fn::If:
+            - RequireSameAccountKmsKeyPolicyForEc2StartInstancesTrue
+            - PolicyName: KmsForEc2StartInstancesRequireSameAccountKmsKeyPolicy
+              PolicyDocument:
+                Version: "2012-10-17"
+                Statement:
+                  - Effect: Allow
+                    Action:
+                      - kms:CreateGrant
+                    NotResource: !Sub "arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:*"
+                    Condition:
+                      StringEquals: { "kms:ViaService": !Sub "ec2.${AWS::Region}.amazonaws.com" }
+                      Bool: { "kms:GrantIsForAWSResource": "true" }
+            - !Ref AWS::NoValue
+
+        - Fn::If:
+            - RequireSameAccountKmsKeyPolicyForEc2StartInstancesTrue
+            - !Ref AWS::NoValue
+            - PolicyName: KmsForEc2StartInstances
+              PolicyDocument:
+                Version: "2012-10-17"
+                Statement:
+                  - Effect: Allow
+                    Action:
+                      - kms:CreateGrant
+                    Resource: "*"
+                    Condition:
+                      StringEquals: { "kms:ViaService": !Sub "ec2.${AWS::Region}.amazonaws.com" }
+                      Bool: { "kms:GrantIsForAWSResource": "true" }
 
         - PolicyName: RdsWrite
           PolicyDocument:


### PR DESCRIPTION
Allows starting EC2 instances whose EBS volumes are encrypted with same-account custom KMS keys, even if the key policies don't explicitly allow it. Can be disabled, requiring a key policy addition even for same-account keys (old behavior).

Goal: `sched-start` tag works for more people without KMS key policy changes

I don't like expanding same-account key usage -- least of all, `CreateGrant` -- beyond what the person who wrote the key policy intended, but AWS made the same choice in [AWSBackupServiceRolePolicyForBackup](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSBackupServiceRolePolicyForBackup.html) .

Other-account keys are safer because the key policy is **always** the security barrier.