### PR TITLE
EventBridge Scheduler, Python bug fix, small improvements

### DIFF
--- a/cloudformation/lights_off_aws.yaml
+++ b/cloudformation/lights_off_aws.yaml
@@ -1526,28 +1526,6 @@ Resources:
           MaximumRetryAttempts: 0
       State: !If [ EnableTrue, ENABLED, DISABLED ]
 
-  # FindLambdaFnSched:
-  #   Type: AWS::Events::Rule
-  #   Properties:
-  #     Description: >-
-  #       Every 10 minutes (do not change!): run Find AWS Lambda function
-  #     ScheduleExpression: "cron(01,11,21,31,41,51 * * * ? *)"
-  #     State:
-  #       Fn::If:
-  #         - EnableTrue
-  #         - ENABLED
-  #         - DISABLED
-  #     Targets: [ { Arn: !GetAtt FindLambdaFn.Arn, Id: !Ref FindLambdaFn } ]
-
-  # # Administrator should block other invocation of this AWS Lambda function
-  # FindLambdaFnPerm:
-  #   Type: AWS::Lambda::Permission
-  #   Properties:
-  #     Action: lambda:InvokeFunction
-  #     FunctionName: !Ref FindLambdaFn
-  #     Principal: events.amazonaws.com
-  #     SourceArn: !GetAtt FindLambdaFnSched.Arn
-
   DoLambdaFnLogGrp:
     Type: AWS::Logs::LogGroup
     Properties:

--- a/cloudformation/lights_off_aws.yaml
+++ b/cloudformation/lights_off_aws.yaml
@@ -1482,7 +1482,6 @@ Resources:
 
   FindLambdaFnSchedGrp:
     Type: AWS::Scheduler::ScheduleGroup
-    Properties:
 
   # Administrator should block other invocation of this AWS Lambda function
   InvokeFindLambdaFnRole:
@@ -1508,7 +1507,7 @@ Resources:
                 Action: lambda:InvokeFunction
                 Resource: !GetAtt FindLambdaFn.Arn
 
-  FindLambdaFnSched:
+  FindLambdaFnSched2:
     Type: AWS::Scheduler::Schedule
     Properties:
       GroupName: !Ref FindLambdaFnSchedGrp

--- a/cloudformation/lights_off_aws.yaml
+++ b/cloudformation/lights_off_aws.yaml
@@ -8,13 +8,13 @@ Description: |-
 
 Parameters:
 
-  PlaceholderHelp:
-    Type: String
-    Default: "https://github.com/sqlxpert/lights-off-aws#quick-start"
-
   PlaceholderSuggestedStackName:
     Type: String
     Default: "LightsOff"
+
+  PlaceholderHelp:
+    Type: String
+    Default: "https://github.com/sqlxpert/lights-off-aws#quick-start"
 
   Enable:
     Type: String
@@ -39,9 +39,9 @@ Parameters:
       backups. Specify only the name, not the ARN. For a StackSet, the role
       must exist, and have the same name, in every target AWS account. Roles
       are account-wide, not regional. AWS Backup creates
-      "service-role/AWSBackupDefaultServiceRole" the first time you start a
-      backup job in the AWS Console. Otherwise, if you want to use this role,
-      you must create it explicitly. See
+      "service-role/AWSBackupDefaultServiceRole" the first time you start an
+      on-demand backup in the AWS Console. Otherwise, if you want to use this
+      role, you must create it explicitly. See
       https://docs.aws.amazon.com/aws-backup/latest/devguide/iam-service-roles.html#default-service-roles
       . Security warning: The AWS Lambda execution role for the "Do" function
       receives permission to iam:PassRole the backup role to AWS Backup.
@@ -54,8 +54,8 @@ Parameters:
       ARN. The vault must have been created in the same AWS account and region
       where you are creating this stack. For a StackSet, the vault must exist,
       and have the same name, in every target AWS account and region. AWS
-      Backup creates the "Default" vault the first time you access the Backup
-      Vaults page in the AWS Console. Otherwise, you must explicitly create a
+      Backup creates the "Default" vault the first time you access the list of
+      vaults in the AWS Console. Otherwise, you must explicitly create a
       vault. See
       https://docs.aws.amazon.com/aws-backup/latest/devguide/create-a-vault.html
     Default: "Default"
@@ -256,8 +256,8 @@ Metadata:
       - Label:
           default: For Reference
         Parameters:
-          - PlaceholderHelp
           - PlaceholderSuggestedStackName
+          - PlaceholderHelp
       - Label:
           default: Essential
         Parameters:
@@ -359,10 +359,9 @@ Conditions:
     !Equals [ !Ref RequireSameAccountKmsKeyPolicyForEc2StartInstances, "true" ]
 
   SqsKmsKeyBlank: !Equals [ !Ref SqsKmsKey, "" ]
-
   SqsKmsKeyCustom:
     Fn::And:
-      - !Not [ !Equals [ !Ref SqsKmsKey, "" ] ]
+      - !Not [ !Condition SqsKmsKeyBlank ]
       - !Not [ !Equals [ !Ref SqsKmsKey, "alias/aws/sqs" ] ]
 
   DoLambdaFnRoleAttachLocalPolicyNameBlank:
@@ -682,8 +681,7 @@ Resources:
               - Effect: Allow
                 Action: backup:StartBackupJob
                 Resource: !Sub "arn:${AWS::Partition}:backup:${AWS::Region}:${AWS::AccountId}:backup-vault:${BackupVaultName}"
-              - Sid: Changed
-                Effect: Allow
+              - Effect: Allow
                 Action: iam:PassRole
                 Resource: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${BackupRoleName}"
                 Condition:
@@ -925,7 +923,7 @@ Resources:
             # The JSON encoder in the AWS Lambda Python runtime isn't configured to
             # serialize datatime values in responses returned by AWS's own Python SDK!
             #
-            # Powertools for Lambda is too heavy for a simple deployment.
+            # Alternative considered:
             # https://docs.powertools.aws.dev/lambda/python/latest/core/logger/
 
             logger.log(
@@ -940,11 +938,11 @@ Resources:
             completed. For example, it may take hours for a backup to become available.
             Checking completion is left to other tools.
             """
-            return all([
-              isinstance(resp, dict),
-              isinstance(resp.get("ResponseMetadata", None), dict),
-              resp["ResponseMetadata"].get("HTTPStatusCode", 0) == 200
-            ])
+            return (
+              isinstance(resp, dict)
+              and isinstance(resp.get("ResponseMetadata"), dict)
+              and (resp["ResponseMetadata"].get("HTTPStatusCode") == 200)
+            )
 
 
           def sqs_send_log(cycle_start_str, send_kwargs, entry_type, entry_value):
@@ -954,9 +952,9 @@ Resources:
               log_level = logging.INFO
             else:
               log_level = logging.ERROR
-              log("START", cycle_start_str, log_level=log_level)
-            log("SQS_SEND", send_kwargs, log_level=log_level)
-            log(entry_type, entry_value, log_level=log_level)
+              log("START", cycle_start_str, log_level)
+            log("SQS_SEND", send_kwargs, log_level)
+            log(entry_type, entry_value, log_level)
 
 
           def op_log(
@@ -964,11 +962,11 @@ Resources:
           ):
             """Log Lambda function event, optional error, optional boto3 response
             """
-            log("LAMBDA_EVENT", event, log_level=log_level)
+            log("LAMBDA_EVENT", event, log_level)
             if resp is not None:
-              log("AWS_RESPONSE", resp, log_level=log_level)
+              log("AWS_RESPONSE", resp, log_level)
             if entry_type:
-              log(entry_type, entry_value, log_level=log_level)
+              log(entry_type, entry_value, log_level)
 
 
           def tag_key_join(tag_key_words):
@@ -1011,7 +1009,7 @@ Resources:
             msg_out = json.dumps(msg_in)
             msg_out_len = len(bytes(msg_out, "utf-8"))
             if msg_out_len > QUEUE_MSG_BYTES_MAX:
-              log("QUEUE_MSG", msg_out, log_level=logging.ERROR)
+              log("QUEUE_MSG", msg_out, logging.ERROR)
               raise SQSMessageTooLong()
             return msg_out
 
@@ -1021,14 +1019,19 @@ Resources:
 
           def svc_client_get(svc):
             """Take an AWS service, return a boto3 client, creating it if needed
+
+            boto3 method references can only be resolved at run-time, against an
+            instance of an AWS service's Client class.
+            http://boto3.readthedocs.io/en/latest/guide/events.html#extensibility-guide
+
+            Alternatives considered:
+            https://github.com/boto/boto3/issues/3197#issue-1175578228
+            https://github.com/aws-samples/boto-session-manager-project
             """
-            if svc_clients.get(svc, None) is None:
+            if svc not in svc_clients:
               svc_clients[svc] = boto3.client(
                 svc, config=botocore.config.Config(retries={"mode": "standard"})
               )
-              # boto3 method references can only be resolved at run-time,
-              # against an instance of an AWS service's Client class.
-              # http://boto3.readthedocs.io/en/latest/guide/events.html#extensibility-guide
             return svc_clients[svc]
 
 
@@ -1142,11 +1145,11 @@ Resources:
                     op = self.ops[op_tags_matched[0]]
                     op.queue(rsrc, cycle_start_str, cycle_cutoff_epoch_str)
                   elif op_tags_matched_count > 1:
-                    log("START", cycle_start_str, log_level=logging.ERROR)
+                    log("START", cycle_start_str, logging.ERROR)
                     log(
                       "MULTIPLE_OPS",
                       {"arn": self.arn(rsrc), "tag_keys": op_tags_matched},
-                      log_level=logging.ERROR
+                      logging.ERROR
                     )
 
 
@@ -1477,27 +1480,73 @@ Resources:
                 raise RuntimeError()
         # ZIPFILE_END
 
-  FindLambdaFnSched:
-    Type: AWS::Events::Rule
+  FindLambdaFnSchedGrp:
+    Type: AWS::Scheduler::ScheduleGroup
     Properties:
-      Description: >-
-        Every 10 minutes (do not change!): run Find AWS Lambda function
-      ScheduleExpression: "cron(01,11,21,31,41,51 * * * ? *)"
-      State:
-        Fn::If:
-          - EnableTrue
-          - ENABLED
-          - DISABLED
-      Targets: [ { Arn: !GetAtt FindLambdaFn.Arn, Id: !Ref FindLambdaFn } ]
 
   # Administrator should block other invocation of this AWS Lambda function
-  FindLambdaFnPerm:
-    Type: AWS::Lambda::Permission
+  InvokeFindLambdaFnRole:
+    Type: AWS::IAM::Role
     Properties:
-      Action: lambda:InvokeFunction
-      FunctionName: !Ref FindLambdaFn
-      Principal: events.amazonaws.com
-      SourceArn: !GetAtt FindLambdaFnSched.Arn
+      Description: !Sub "For ${AWS::Region} region"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal: { Service: scheduler.amazonaws.com }
+            Action: sts:AssumeRole
+            Condition:
+              ArnEquals:
+                "aws:SourceArn": !GetAtt FindLambdaFnSchedGrp.Arn
+                # Must be a schedule group, not an individual schedule!
+      Policies:
+        - PolicyName: LambdaInvoke
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: lambda:InvokeFunction
+                Resource: !GetAtt FindLambdaFn.Arn
+
+  FindLambdaFnSched:
+    Type: AWS::Scheduler::Schedule
+    Properties:
+      GroupName: !Ref FindLambdaFnSchedGrp
+      Description: >-
+        Every 10 minutes (do not change!): invoke "Find" AWS Lambda function
+      ScheduleExpressionTimezone: UTC
+      ScheduleExpression: "cron(01,11,21,31,41,51 * * * ? *)"
+      # cron(minutes hours day-of-month month day-of-week year)
+      # https://docs.aws.amazon.com/scheduler/latest/UserGuide/schedule-types.html#cron-based
+      FlexibleTimeWindow: { Mode: "OFF" }  # Quotes required!
+      Target:
+        RoleArn: !GetAtt InvokeFindLambdaFnRole.Arn
+        Arn: !GetAtt FindLambdaFn.Arn
+        RetryPolicy:
+          MaximumRetryAttempts: 0
+      State: !If [ EnableTrue, ENABLED, DISABLED ]
+
+  # FindLambdaFnSched:
+  #   Type: AWS::Events::Rule
+  #   Properties:
+  #     Description: >-
+  #       Every 10 minutes (do not change!): run Find AWS Lambda function
+  #     ScheduleExpression: "cron(01,11,21,31,41,51 * * * ? *)"
+  #     State:
+  #       Fn::If:
+  #         - EnableTrue
+  #         - ENABLED
+  #         - DISABLED
+  #     Targets: [ { Arn: !GetAtt FindLambdaFn.Arn, Id: !Ref FindLambdaFn } ]
+
+  # # Administrator should block other invocation of this AWS Lambda function
+  # FindLambdaFnPerm:
+  #   Type: AWS::Lambda::Permission
+  #   Properties:
+  #     Action: lambda:InvokeFunction
+  #     FunctionName: !Ref FindLambdaFn
+  #     Principal: events.amazonaws.com
+  #     SourceArn: !GetAtt FindLambdaFnSched.Arn
 
   DoLambdaFnLogGrp:
     Type: AWS::Logs::LogGroup
@@ -1614,7 +1663,7 @@ Resources:
             # The JSON encoder in the AWS Lambda Python runtime isn't configured to
             # serialize datatime values in responses returned by AWS's own Python SDK!
             #
-            # Powertools for Lambda is too heavy for a simple deployment.
+            # Alternative considered:
             # https://docs.powertools.aws.dev/lambda/python/latest/core/logger/
 
             logger.log(
@@ -1629,11 +1678,11 @@ Resources:
             completed. For example, it may take hours for a backup to become available.
             Checking completion is left to other tools.
             """
-            return all([
-              isinstance(resp, dict),
-              isinstance(resp.get("ResponseMetadata", None), dict),
-              resp["ResponseMetadata"].get("HTTPStatusCode", 0) == 200
-            ])
+            return (
+              isinstance(resp, dict)
+              and isinstance(resp.get("ResponseMetadata"), dict)
+              and (resp["ResponseMetadata"].get("HTTPStatusCode") == 200)
+            )
 
 
           def sqs_send_log(cycle_start_str, send_kwargs, entry_type, entry_value):
@@ -1643,9 +1692,9 @@ Resources:
               log_level = logging.INFO
             else:
               log_level = logging.ERROR
-              log("START", cycle_start_str, log_level=log_level)
-            log("SQS_SEND", send_kwargs, log_level=log_level)
-            log(entry_type, entry_value, log_level=log_level)
+              log("START", cycle_start_str, log_level)
+            log("SQS_SEND", send_kwargs, log_level)
+            log(entry_type, entry_value, log_level)
 
 
           def op_log(
@@ -1653,11 +1702,11 @@ Resources:
           ):
             """Log Lambda function event, optional error, optional boto3 response
             """
-            log("LAMBDA_EVENT", event, log_level=log_level)
+            log("LAMBDA_EVENT", event, log_level)
             if resp is not None:
-              log("AWS_RESPONSE", resp, log_level=log_level)
+              log("AWS_RESPONSE", resp, log_level)
             if entry_type:
-              log(entry_type, entry_value, log_level=log_level)
+              log(entry_type, entry_value, log_level)
 
 
           def tag_key_join(tag_key_words):
@@ -1700,7 +1749,7 @@ Resources:
             msg_out = json.dumps(msg_in)
             msg_out_len = len(bytes(msg_out, "utf-8"))
             if msg_out_len > QUEUE_MSG_BYTES_MAX:
-              log("QUEUE_MSG", msg_out, log_level=logging.ERROR)
+              log("QUEUE_MSG", msg_out, logging.ERROR)
               raise SQSMessageTooLong()
             return msg_out
 
@@ -1710,14 +1759,19 @@ Resources:
 
           def svc_client_get(svc):
             """Take an AWS service, return a boto3 client, creating it if needed
+
+            boto3 method references can only be resolved at run-time, against an
+            instance of an AWS service's Client class.
+            http://boto3.readthedocs.io/en/latest/guide/events.html#extensibility-guide
+
+            Alternatives considered:
+            https://github.com/boto/boto3/issues/3197#issue-1175578228
+            https://github.com/aws-samples/boto-session-manager-project
             """
-            if svc_clients.get(svc, None) is None:
+            if svc not in svc_clients:
               svc_clients[svc] = boto3.client(
                 svc, config=botocore.config.Config(retries={"mode": "standard"})
               )
-              # boto3 method references can only be resolved at run-time,
-              # against an instance of an AWS service's Client class.
-              # http://boto3.readthedocs.io/en/latest/guide/events.html#extensibility-guide
             return svc_clients[svc]
 
 
@@ -1831,11 +1885,11 @@ Resources:
                     op = self.ops[op_tags_matched[0]]
                     op.queue(rsrc, cycle_start_str, cycle_cutoff_epoch_str)
                   elif op_tags_matched_count > 1:
-                    log("START", cycle_start_str, log_level=logging.ERROR)
+                    log("START", cycle_start_str, logging.ERROR)
                     log(
                       "MULTIPLE_OPS",
                       {"arn": self.arn(rsrc), "tag_keys": op_tags_matched},
-                      log_level=logging.ERROR
+                      logging.ERROR
                     )
 
 
@@ -2180,10 +2234,10 @@ Resources:
     Type: AWS::Lambda::EventSourceMapping
     DependsOn: DoLambdaFnInvokeLambdaPerm
     Properties:
-      BatchSize: 1
+      EventSourceArn: !GetAtt OperationQueue.Arn
       MaximumBatchingWindowInSeconds: 20  # long polling (lowest cost)
+      BatchSize: 1
+      FunctionName: !GetAtt DoLambdaFn.Arn
       ScalingConfig:
         MaximumConcurrency: !Ref DoLambdaFnReservedConcurrentExecutions
       Enabled: !Ref Enable
-      EventSourceArn: !GetAtt OperationQueue.Arn
-      FunctionName: !GetAtt DoLambdaFn.Arn

--- a/cloudformation/lights_off_aws_prereq.yaml
+++ b/cloudformation/lights_off_aws_prereq.yaml
@@ -87,7 +87,7 @@ Resources:
 
               - Effect: Allow
                 Action:
-                  - lambda:CreateFunction
+                  - lambda:CreateFunction  # Also iam:PassRole
                   - lambda:GetFunction
                   - lambda:DeleteFunction
                   - lambda:UpdateFunctionCode
@@ -100,7 +100,7 @@ Resources:
                   - lambda:TagResource
                   - lambda:UntagResource
                 Resource:
-                  - !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${StackNameLike}*"
+                  - !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${StackNameLike}-*"
               - Effect: Allow
                 Action:
                   - lambda:CreateEventSourceMapping
@@ -111,7 +111,7 @@ Resources:
                 Condition:
                   ArnLikeIfExists:
                     "lambda:FunctionArn":
-                      - !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${StackNameLike}*"
+                      - !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${StackNameLike}-*"
               - Effect: Allow
                 Action:
                   - lambda:TagResource
@@ -136,7 +136,7 @@ Resources:
                   - logs:UntagLogGroup
                   - logs:UntagResource
                 Resource:
-                  - !Sub "arn:${AWS::Partition}:logs:*:${AWS::AccountId}:log-group:${StackNameLike}*"
+                  - !Sub "arn:${AWS::Partition}:logs:*:${AWS::AccountId}:log-group:${StackNameLike}-*"
               - Effect: Allow
                 Action:
                   - logs:DescribeLogGroups
@@ -151,12 +151,21 @@ Resources:
                   - scheduler:TagResource
                   - scheduler:UntagResource
                 Resource:
-                  - !Sub "arn:${AWS::Partition}:scheduler:*:${AWS::AccountId}:schedule-group/${StackNameLike}*"
+                  - !Sub "arn:${AWS::Partition}:scheduler:*:${AWS::AccountId}:schedule-group/${StackNameLike}-*"
+              - Sid: ForDeleteScheduleGroup
+                Effect: Allow
+                Action:
+                  - scheduler:DeleteSchedule
+                  # Possible future requirement:
+                  - scheduler:TagResource
+                  - scheduler:UntagResource
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:scheduler:*:${AWS::AccountId}:schedule/${StackNameLike}-*/*"
               - Effect: Allow
                 Action:
-                  - scheduler:CreateSchedule
+                  - scheduler:CreateSchedule  # Also iam:PassRole
                   - scheduler:GetSchedule
-                  - scheduler:UpdateSchedule
+                  - scheduler:UpdateSchedule  # Also iam:PassRole
                   - scheduler:DeleteSchedule
                   # Possible future requirement:
                   - scheduler:TagResource
@@ -170,7 +179,7 @@ Resources:
                   # arn:PARTITION:logs:REGION:ACCOUNT:log-group:GROUP_NAME:log-stream:STREAM_NAME
                   # arn:PARTITION:scheduler:REGION:ACCOUNT:schedule-group/GROUP_NAME
                   # arn:PARTITION:scheduler:REGION:ACCOUNT:schedule/GROUP_NAME/SCHED_NAME
-                  - !Sub "arn:${AWS::Partition}:scheduler:*:${AWS::AccountId}:schedule/${StackNameLike}*/${StackNameLike}*"
+                  - !Sub "arn:${AWS::Partition}:scheduler:*:${AWS::AccountId}:schedule/${StackNameLike}-*/${StackNameLike}-*"
               - Effect: Allow
                 Action:
                   - scheduler:ListScheduleGroups
@@ -178,24 +187,27 @@ Resources:
                   - scheduler:ListTagsForResource
                 Resource: "*"
 
-              # - Effect: Allow
-              #   Action:
-              #     - events:PutRule
-              #     - events:DescribeRule
-              #     - events:EnableRule
-              #     - events:DisableRule
-              #     - events:DeleteRule
-              #     - events:PutTargets
-              #     - events:ListTargetsByRule
-              #     - events:RemoveTargets
-              #     - events:TagResource
-              #     - events:UntagResource
-              #   Resource:
-              #     - !Sub "arn:${AWS::Partition}:events:*:${AWS::AccountId}:rule/${StackNameLike}*"
-              # - Effect: Allow
-              #   Action:
-              #     - events:ListTagsForResource
-              #   Resource: "*"
+              # Left so that existing users can maintain, and eventually,
+              # delete, the old EventBridge rule (replaced by an EventBridge
+              # schedule)
+              - Effect: Allow
+                Action:
+                  - events:PutRule
+                  - events:DescribeRule
+                  - events:EnableRule
+                  - events:DisableRule
+                  - events:DeleteRule
+                  - events:PutTargets
+                  - events:ListTargetsByRule
+                  - events:RemoveTargets
+                  - events:TagResource
+                  - events:UntagResource
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:events:*:${AWS::AccountId}:rule/${StackNameLike}-*"
+              - Effect: Allow
+                Action:
+                  - events:ListTagsForResource
+                Resource: "*"
 
               - Effect: Allow
                 Action:
@@ -210,7 +222,7 @@ Resources:
                   - sqs:TagQueue
                   - sqs:UntagQueue
                 Resource:
-                  - !Sub "arn:${AWS::Partition}:sqs:*:${AWS::AccountId}:${StackNameLike}*"
+                  - !Sub "arn:${AWS::Partition}:sqs:*:${AWS::AccountId}:${StackNameLike}-*"
               - Effect: Allow
                 Action:
                   - sqs:ListQueues
@@ -220,7 +232,16 @@ Resources:
               - Effect: Allow
                 Action: iam:PassRole
                 Resource:
-                  - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${StackNameLike}*"
+                  - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${StackNameLike}-*"
+                Condition:
+                  StringEquals:
+                    "iam:PassedToService":
+                      - lambda.amazonaws.com
+                      - scheduler.amazonaws.com
+                  ArnLike:
+                    "iam:AssociatedResourceArn":
+                      - !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:${StackNameLike}-*"
+                      - !Sub "arn:${AWS::Partition}:scheduler:*:${AWS::AccountId}:schedule/${StackNameLike}-*/${StackNameLike}-*"
               - Effect: Allow
                 Action:
                   - iam:CreateRole
@@ -238,7 +259,7 @@ Resources:
                   - iam:TagRole
                   - iam:UntagRole
                 Resource:
-                  - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${StackNameLike}*"
+                  - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${StackNameLike}-*"
               - Effect: Allow
                 Action:
                   - iam:ListRoles

--- a/cloudformation/lights_off_aws_prereq.yaml
+++ b/cloudformation/lights_off_aws_prereq.yaml
@@ -8,13 +8,19 @@ Description: |-
 
 Parameters:
 
+  PlaceholderSuggestedStackName:
+    Type: String
+    Default: "LightsOffPrereq"
+
   PlaceholderHelp:
     Type: String
     Default: "https://github.com/sqlxpert/lights-off-aws#least-privilege-installation"
 
-  PlaceholderSuggestedStackName:
+  PlaceholderAdvancedParameters:
     Type: String
-    Default: "LightsOffPrereq"
+    Default: ""
+    AllowedValues:
+      - ""
 
   StackNameLike:
     Type: String
@@ -35,14 +41,14 @@ Metadata:
       - Label:
           default: For Reference
         Parameters:
-          - PlaceholderHelp
           - PlaceholderSuggestedStackName
+          - PlaceholderHelp
       - Label:
           default: Advanced Options
         Parameters:
           - PlaceholderAdvancedParameters
       - Label:
-          default: For stacks created with the deployment role...
+          default: For stacks created using the deployment role...
         Parameters:
           - StackNameLike
     ParameterLabels:
@@ -139,22 +145,57 @@ Resources:
 
               - Effect: Allow
                 Action:
-                  - events:PutRule
-                  - events:DescribeRule
-                  - events:EnableRule
-                  - events:DisableRule
-                  - events:DeleteRule
-                  - events:PutTargets
-                  - events:ListTargetsByRule
-                  - events:RemoveTargets
-                  - events:TagResource
-                  - events:UntagResource
+                  - scheduler:CreateScheduleGroup
+                  - scheduler:GetScheduleGroup
+                  - scheduler:DeleteScheduleGroup
+                  - scheduler:TagResource
+                  - scheduler:UntagResource
                 Resource:
-                  - !Sub "arn:${AWS::Partition}:events:*:${AWS::AccountId}:rule/${StackNameLike}*"
+                  - !Sub "arn:${AWS::Partition}:scheduler:*:${AWS::AccountId}:schedule-group/${StackNameLike}*"
               - Effect: Allow
                 Action:
-                  - events:ListTagsForResource
+                  - scheduler:CreateSchedule
+                  - scheduler:GetSchedule
+                  - scheduler:UpdateSchedule
+                  - scheduler:DeleteSchedule
+                  # Possible future requirement:
+                  - scheduler:TagResource
+                  - scheduler:UntagResource
+                Resource:
+                  # Compare CloudWatch Logs and EventBridge Scheduler.
+                  # Right-trimming the stream name from a LogStream ARN gives
+                  # the ARN of the parent LogGroup, but unfortunately,
+                  # right-trimming the schedule name from a schedule ARN does
+                  # not give the ARN of the parent ScheduleGroup.
+                  # arn:PARTITION:logs:REGION:ACCOUNT:log-group:GROUP_NAME:log-stream:STREAM_NAME
+                  # arn:PARTITION:scheduler:REGION:ACCOUNT:schedule-group/GROUP_NAME
+                  # arn:PARTITION:scheduler:REGION:ACCOUNT:schedule/GROUP_NAME/SCHED_NAME
+                  - !Sub "arn:${AWS::Partition}:scheduler:*:${AWS::AccountId}:schedule/${StackNameLike}*/${StackNameLike}*"
+              - Effect: Allow
+                Action:
+                  - scheduler:ListScheduleGroups
+                  - scheduler:ListSchedules
+                  - scheduler:ListTagsForResource
                 Resource: "*"
+
+              # - Effect: Allow
+              #   Action:
+              #     - events:PutRule
+              #     - events:DescribeRule
+              #     - events:EnableRule
+              #     - events:DisableRule
+              #     - events:DeleteRule
+              #     - events:PutTargets
+              #     - events:ListTargetsByRule
+              #     - events:RemoveTargets
+              #     - events:TagResource
+              #     - events:UntagResource
+              #   Resource:
+              #     - !Sub "arn:${AWS::Partition}:events:*:${AWS::AccountId}:rule/${StackNameLike}*"
+              # - Effect: Allow
+              #   Action:
+              #     - events:ListTagsForResource
+              #   Resource: "*"
 
               - Effect: Allow
                 Action:


### PR DESCRIPTION
- Switch to EventBridge Scheduler (modern).
- Python code:
  - Bug fix: `all([])` elements might not be evaluated in order; revert to `and`s, so that evaluation will stop before an invalid reference can occur.
  - Logging helper function: Treat `log_level` as an optional _and_ positional parameter.
  - Remove a few `None` values (default) from `.get()` , at the risk of explicitness when reading/understanding expressions.
  - Remove an unnecessary `.get()` when checking for cached boto3 `Client`s.
- CloudFormation:
  - Remove a non-informational `Sid`, left over from testing.
  - Move suggested stack name first, for easy copying, in the AWS Console.
  - Re-order AWS Lambda permission properties for reading.
  - Use a `!Condition` lookup to avoid repetition.
  - Add missing placeholder parameter in the deployment role template.
  - Deployment role:
    - Restrict `iam:PassRole` by service and resource ARN.
    - Correctly apply parameterized `StackNameLike` pattern in ARNs (hyphen `-` is once again required between stack name and random string added by CloudFormation).
    - Maintain old permissions for EventBridge, to facilitate transition to EventBridge Scheduler.