### PR TITLE
Reboot removed; sched errors to DLQ; concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ Jump to:
 
    - Stack name: `LightsOff`
 
+   <details>
+     <summary>If stack creation fails with an UnreservedConcurrentExecution error...</summary>
+
+     Request that
+     [Service Quotas &rarr; AWS services  &rarr; AWS Lambda &rarr; Concurrent executions](https://console.aws.amazon.com/servicequotas/home/services/lambda/quotas/L-B99A9384)
+     be increased. The default value is `1000` .
+
+     Lights Off needs 1 unit for a time-critical AWS Lambda function. New AWS
+     accounts start with a quota of 10 units, but AWS always holds back 10,
+     which leaves 0 available for use!
+
+   </details>
+
 4. After about 20 minutes, check whether the EC2 instance is stopped. Restart
    it and delete the `sched-stop` tag.
 

--- a/README.md
+++ b/README.md
@@ -50,16 +50,17 @@ Jump to:
 
    - Stack name: `LightsOff`
 
+   <br>
    <details>
      <summary>If stack creation fails with an UnreservedConcurrentExecution error...</summary>
 
-     Request that
-     [Service Quotas &rarr; AWS services  &rarr; AWS Lambda &rarr; Concurrent executions](https://console.aws.amazon.com/servicequotas/home/services/lambda/quotas/L-B99A9384)
-     be increased. The default value is `1000` .
+   Request that
+   [Service Quotas &rarr; AWS services  &rarr; AWS Lambda &rarr; Concurrent executions](https://console.aws.amazon.com/servicequotas/home/services/lambda/quotas/L-B99A9384)
+   be increased. The default value is `1000` .
 
-     Lights Off needs 1 unit for a time-critical AWS Lambda function. New AWS
-     accounts start with a quota of 10 units, but AWS always holds back 10,
-     which leaves 0 available for use!
+   Lights Off needs 1 unit for a time-critical function. New AWS accounts
+   start with a quota of 10 units, but AWS always holds back 10, which leaves
+   0 available!
 
    </details>
 

--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ for suggesting the new name.
 ## Licenses
 
 |Scope|Link|Included Copy|
-|:---:|:---:|:---:|
+|:---|:---:|:---:|
 |Source code files, and source code embedded in documentation files|[GNU General Public License (GPL) 3.0](http://www.gnu.org/licenses/gpl-3.0.html)|[LICENSE-CODE.md](/LICENSE-CODE.md)|
 |Documentation files (including this readme file)|[GNU Free Documentation License (FDL) 1.3](http://www.gnu.org/licenses/fdl-1.3.html)|[LICENSE-DOC.md](/LICENSE-DOC.md)|
 

--- a/README.md
+++ b/README.md
@@ -321,7 +321,11 @@ account+region combination. To deploy to multiple regions and/or AWS accounts,
 2. Complete the prerequisites for creating a _StackSet_ with
    [service-managed permissions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-enable-trusted-access.html).
 
-3. In the management AWS account (or a delegated administrator account),
+3. Make sure that every target AWS Account has a sufficient AWS Lambda
+   `Concurrent executions` quota. See the note at the end of
+   [Quick Start](#quick-start) Step 3.
+
+4. In the management AWS account (or a delegated administrator account),
    create a
    [CloudFormation StackSet](https://console.aws.amazon.com/cloudformation/home#/stacksets).
    Select Upload a template file, then select Choose file and upload a
@@ -331,7 +335,7 @@ account+region combination. To deploy to multiple regions and/or AWS accounts,
 
    - StackSet name: `LightsOff`
 
-4. Two pages later, under Deployment targets, select Deploy to Organizational
+5. Two pages later, under Deployment targets, select Deploy to Organizational
    Units (OUs). Enter the AWS OU ID of the target Organizational Unit. Lights
    Off will be deployed to all AWS accounts within this Organizational Unit.
    Toward the bottom of the page, specify the target regions.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ Jump to:
 ||`sched-stop`|`sched-hibernate`|`sched-backup`|
 |:---|:---:|:---:|:---:|
 ||**`sched-start`**|||
-||**`sched-reboot`**|||
 |EC2:||||
 |[Instance](https://console.aws.amazon.com/ec2/home#Instances)|&check;|&check;|&rarr; Image (AMI)|
 |[EBS Volume](https://console.aws.amazon.com/ec2/home#Volumes)|||&rarr; Snapshot|
@@ -286,9 +285,12 @@ form (example: `2024-12-31T14:00Z`).
 
 - Check the
   [LightsOff CloudWatch log groups](https://console.aws.amazon.com/cloudwatch/home#logsV2:log-groups$3FlogGroupNameFilter$3DLightsOff-).
-- Log entries are JSON objects. Entries from Lights Off include `"level"`,
-  `"type"` and `"value"` keys.
-- For more data, change the `LogLevel` in CloudFormation.
+  - Log entries are JSON objects. Entries from Lights Off include `"level"`,
+    `"type"` and `"value"` keys.
+  - For more data, change the `LogLevel` in CloudFormation.
+- Check the `ErrorQueue`
+  [SQS queue](https://console.aws.amazon.com/sqs/v3/home#/queues)
+  for undeliverable "Find" and "Do" events.
 - Check CloudTrail for the final stages of `sched-start` and `sched-backup`
   operations.
 
@@ -376,14 +378,14 @@ software at your own risk. You are encouraged to evaluate the source code._
 
 - A least-privilege queue policy. The operation queue can only consume
   messages from the "Find" function and produce messages for the "Do" function
-  (or a dead-letter queue, if an operation fails). Encryption in transit is
+  (or an error queue, if an operation fails). Encryption in transit is
   required.
 
 - Readable IAM policies, formatted as CloudFormation YAML rather than JSON,
   and broken down into discrete statements by service, resource or principal.
 
 - Optional encryption at rest with the AWS Key Management System (KMS), for
-  queue message bodies (which contain resource identifiers) and for logs (may
+  queue message bodies (may contain resource identifiers) and for logs (may
   contain resource metadata).
 
 - No data storage other than in queues and logs, with short or configurable
@@ -418,8 +420,8 @@ software at your own risk. You are encouraged to evaluate the source code._
 
 - Separate production workloads. You might choose not to deploy Lights Off to
   AWS accounts used for production, or you might add a custom policy to the
-  "Do" function's role, denying authority to reboot and stop production
-  resources ( `AttachLocalPolicy` in CloudFormation).
+  "Do" function's role, denying authority to stop production resources (
+  `AttachLocalPolicy` in CloudFormation).
 
 </details>
 
@@ -484,7 +486,6 @@ _clusters_ (RDS database _instances_ were already supported) required adding:
       {
         ("start", ): {},
         ("stop", ): {},
-        ("reboot", ): {},
         ("backup", ): {"class": AWSOpBackUp},
       },
       rsrc_id_key_suffix="Identifier",

--- a/cloudformation/.cfnlintrc.yaml
+++ b/cloudformation/.cfnlintrc.yaml
@@ -1,5 +1,5 @@
 ---
-# Start, reboot, stop and back up AWS resources using schedules in tags
+# Start, stop and back up AWS resources tagged with cron schedules
 # github.com/sqlxpert/lights-off-aws/  GPLv3  Copyright Paul Marcelin
 
 ignore_checks:

--- a/cloudformation/.yamllint.yaml
+++ b/cloudformation/.yamllint.yaml
@@ -1,5 +1,5 @@
 ---
-# Start, reboot, stop and back up AWS resources using schedules in tags
+# Start, stop and back up AWS resources tagged with cron schedules.
 # github.com/sqlxpert/lights-off-aws/  GPLv3  Copyright Paul Marcelin
 
 extends: default

--- a/cloudformation/lights_off_aws.yaml
+++ b/cloudformation/lights_off_aws.yaml
@@ -125,6 +125,17 @@ Parameters:
     MinValue: -1
     Default: -1
 
+  DoLambdaFnMaximumConcurrency:
+    Type: Number
+    Description: >-
+      How many scheduled operations may be started in parallel. The minimum is
+      2. If you set reserved parallel operations to 2 or more, set this no
+      larger than reserved parallel operations.
+      See
+      https://docs.aws.amazon.com/lambda/latest/dg/services-sqs-scaling.html#events-sqs-max-concurrency
+    MinValue: 2
+    Default: 5
+
   RequireSameAccountKmsKeyPolicyForEc2StartInstances:
     Type: String
     Description: >-
@@ -287,6 +298,7 @@ Metadata:
           default: AWS Lambda function to do scheduled operations
         Parameters:
           - DoLambdaFnReservedConcurrentExecutions
+          - DoLambdaFnMaximumConcurrency
           - RequireSameAccountKmsKeyPolicyForEc2StartInstances
           - DoLambdaFnRoleAttachLocalPolicyName
           - DoLambdaFnMemoryMB
@@ -330,7 +342,9 @@ Metadata:
       FindLambdaFnTimeoutSecs:
         default: Seconds before timeout
       DoLambdaFnReservedConcurrentExecutions:
-        default: Number of parallel operations
+        default: Number of reserved parallel operations
+      DoLambdaFnMaximumConcurrency:
+        default: Maximum number of parallel operations
       RequireSameAccountKmsKeyPolicyForEc2StartInstances:
         default: Require same-account KMS key policy for EC2 sched-start
       DoLambdaFnRoleAttachLocalPolicyName:
@@ -697,25 +711,21 @@ Resources:
             Principal: "*"
             Action: sqs:GetQueueAttributes
             Resource: !GetAtt ErrorQueue.Arn
-          - Sid: DeadLetterSource
-            Effect: Allow
+          - Effect: Allow
+            Principal: "*"
+            Action: sqs:SendMessage
+            Resource: !GetAtt ErrorQueue.Arn
+            Condition:
+              ArnEquals:
+                "aws:PrincipalArn":
+                  - !GetAtt InvokeFindLambdaFnRole.Arn
+          - Effect: Allow
             Principal: "*"
             Action: sqs:SendMessage
             Resource: !GetAtt ErrorQueue.Arn
             Condition:
               ArnEquals:
                 "aws:SourceArn":
-                  - !GetAtt FindLambdaFnSchedGrp.Arn
-                  - !GetAtt OperationQueue.Arn
-          - Sid: ExclusiveSource
-            Effect: Deny
-            Principal: "*"
-            Action: sqs:SendMessage
-            Resource: !GetAtt ErrorQueue.Arn
-            Condition:
-              ArnNotEquals:
-                "aws:SourceArn":
-                  - !GetAtt FindLambdaFnSchedGrp.Arn
                   - !GetAtt OperationQueue.Arn
 
   OperationQueuePol:
@@ -1439,7 +1449,7 @@ Resources:
                   event,
                   entry_type="EXPIRED_OP",
                   entry_value="Schedule fewer operations per 10-minute cycle or "
-                  "increase DoLambdaFnReservedConcurrentExecutions in CloudFormation"
+                  "increase DoLambdaFnMaximumConcurrency in CloudFormation"
                 )
                 raise RuntimeError()
 
@@ -1501,7 +1511,8 @@ Resources:
         RoleArn: !GetAtt InvokeFindLambdaFnRole.Arn
         Arn: !GetAtt FindLambdaFn.Arn
         RetryPolicy:
-          MaximumRetryAttempts: 0
+          MaximumRetryAttempts: 0  # ReservedConcurrentExecutions >= 0
+          MaximumEventAgeInSeconds: 300  # 5 minutes (future use)
         DeadLetterConfig: { Arn: !GetAtt ErrorQueue.Arn }
       State: !If [ EnableTrue, ENABLED, DISABLED ]
 
@@ -2158,7 +2169,7 @@ Resources:
                   event,
                   entry_type="EXPIRED_OP",
                   entry_value="Schedule fewer operations per 10-minute cycle or "
-                  "increase DoLambdaFnReservedConcurrentExecutions in CloudFormation"
+                  "increase DoLambdaFnMaximumConcurrency in CloudFormation"
                 )
                 raise RuntimeError()
 
@@ -2197,9 +2208,5 @@ Resources:
       BatchSize: 1
       FunctionName: !GetAtt DoLambdaFn.Arn
       ScalingConfig:
-        MaximumConcurrency:
-          Fn::If:
-            - DoLambdaFnReservedConcurrentExecutionsOff
-            - 5
-            - !Ref DoLambdaFnReservedConcurrentExecutions
+        MaximumConcurrency: !Ref DoLambdaFnMaximumConcurrency
       Enabled: !Ref Enable

--- a/cloudformation/lights_off_aws.yaml
+++ b/cloudformation/lights_off_aws.yaml
@@ -2,7 +2,7 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
 Description: |-
-  Start, reboot, stop and back up AWS resources tagged with cron schedules.
+  Start, stop and back up AWS resources tagged with cron schedules.
 
   github.com/sqlxpert/lights-off-aws/  GPLv3  Copyright Paul Marcelin
 
@@ -119,10 +119,11 @@ Parameters:
   DoLambdaFnReservedConcurrentExecutions:
     Type: Number
     Description: >-
-      How many scheduled operations can be done in parallel. See
+      How many scheduled operations can definitely be started in parallel. To
+      decline access to AWS Lambda reserved concurrency, set this to -1. See
       https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html#configuration-concurrency-reserved
-    MinValue: 0
-    Default: 5
+    MinValue: -1
+    Default: -1
 
   RequireSameAccountKmsKeyPolicyForEc2StartInstances:
     Type: String
@@ -147,7 +148,7 @@ Parameters:
     Description: >-
       The name of a customer-managed IAM policy to be attached to the "Do"
       function's role. By including "Effect": "Deny" statements, you could,
-      for example, prevent the rebooting or stopping of production resources.
+      for example, prevent the stopping of production resources.
       Specify only the name, not the ARN. For a StackSet, the policy must
       exist, and have exactly the same name, in every target AWS account.
       Policies are account-wide, not regional. See
@@ -177,22 +178,6 @@ Parameters:
       https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#events-sqs-queueconfig
     Default: 90
 
-  SqsKmsKey:
-    Type: String
-    Description: >-
-      If this is blank, queue messages will not be encrypted. To use the
-      AWS-managed key (which does not support key policy restrictions, or
-      cross-region or cross-account usage), specify "alias/aws/sqs". To use a
-      custom key, specify "ACCOUNT:key/KEY_ID". Whether the custom key is a
-      single-region key, a multi-region key primary, or a multi-region key
-      replica, it must be in the same region where you are creating this
-      stack. If the custom key is in a different AWS account than this stack,
-      you must update the key policy to allow cross-account usage. For a
-      StackSet, if you wish to use a custom key, it must be multi-region
-      ("mrk-" prefix in the KEY_ID), and a replica (or the primary key itself)
-      must exist in every target region.
-    Default: ""
-
   QueueMessageBytesMax:
     Type: Number
     Description: >-
@@ -201,15 +186,31 @@ Parameters:
     Default: 32768  # 32 KiB (worst case when copying 50 long tags)
     MaxValue: 262144  # 256 KiB
 
-  OperationFailedQueueMessageRetentionPeriodSecs:
+  ErrorQueueMessageRetentionPeriodSecs:
     Type: Number
     Description: >-
-      How many seconds to keep queue messages for scheduled operations that
-      failed. For consistency with the log retention period, and if CloudWatch
-      Logs and SQS allow, set this to LogsRetainDays * 86400 . See
-      MessageRetentionPeriod in
+      How many seconds to keep error queue messages. For consistency with the
+      log retention period, and if CloudWatch Logs and SQS allow, set this to
+      LogsRetainDays * 86400 . See MessageRetentionPeriod in
       https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SetQueueAttributes.html#API_SetQueueAttributes_RequestParameters
     Default: 604800
+
+  SqsKmsKey:
+    Type: String
+    Description: >-
+      If this is blank, default non-KMS SQS encryption applies. To use the
+      AWS-managed key (which does not support key policy restrictions, or
+      cross-region or cross-account usage), specify "alias/aws/sqs". To use a
+      custom key, specify "ACCOUNT:key/KEY_ID". Whether the custom key is a
+      single-region key, a multi-region key primary, or a multi-region key
+      replica, it must be in the same region where you are creating this
+      stack. Even if the custom key is in the same AWS account as this stack,
+      you must update the key policy to allow usage by SQS. See
+      https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-key-management.html#compatibility-with-aws-services
+      . For a StackSet, if you wish to use a custom key, it must be
+      multi-region ("mrk-" prefix in the KEY_ID), and a replica (or the
+      primary key itself) must exist in every target region.
+    Default: ""
 
   LogsRetainDays:
     Type: Number
@@ -289,12 +290,12 @@ Metadata:
           - DoLambdaFnMemoryMB
           - DoLambdaFnTimeoutSecs
       - Label:
-          default: SQS queues for scheduled operations
+          default: SQS queues for errors and scheduled operations
         Parameters:
           - OperationQueueVisibilityTimeoutSecs
-          - SqsKmsKey
           - QueueMessageBytesMax
-          - OperationFailedQueueMessageRetentionPeriodSecs
+          - ErrorQueueMessageRetentionPeriodSecs
+          - SqsKmsKey
       - Label:
           default: Logs
         Parameters:
@@ -340,10 +341,10 @@ Metadata:
         default: Seconds before message visibility timeout
       QueueMessageBytesMax:
         default: Maximum bytes in a message
+      ErrorQueueMessageRetentionPeriodSecs:
+        default: Seconds before deleting an error queue message
       SqsKmsKey:
         default: KMS encryption key
-      OperationFailedQueueMessageRetentionPeriodSecs:
-        default: Seconds before deleting a message for a failed operation
       LogsRetainDays:
         default: Days before deleting
       LogLevel:
@@ -367,14 +368,18 @@ Conditions:
   DoLambdaFnRoleAttachLocalPolicyNameBlank:
     !Equals [ !Ref DoLambdaFnRoleAttachLocalPolicyName, "" ]
 
+  DoLambdaFnReservedConcurrentExecutionsOff:
+    !Equals [ !Ref DoLambdaFnReservedConcurrentExecutions, -1 ]
+
   CloudWatchLogsKmsKeyBlank: !Equals [ !Ref CloudWatchLogsKmsKey, "" ]
 
 Resources:
 
-  OperationFailedQueue:
+  ErrorQueue:
     Type: AWS::SQS::Queue
     Properties:
       DelaySeconds: 0
+      SqsManagedSseEnabled: !If [ SqsKmsKeyBlank, true, false ]
       KmsMasterKeyId:
         Fn::If:
           - SqsKmsKeyBlank
@@ -384,18 +389,15 @@ Resources:
               - !Sub "arn:${AWS::Partition}:kms:${AWS::Region}:${SqsKmsKey}"
               - !Ref SqsKmsKey
       KmsDataKeyReusePeriodSeconds:
-        Fn::If:
-          - SqsKmsKeyBlank
-          - !Ref AWS::NoValue
-          - 86400  # seconds (24 hours)
-      MaximumMessageSize: !Ref QueueMessageBytesMax
-      MessageRetentionPeriod: !Ref OperationFailedQueueMessageRetentionPeriodSecs
+        !If [ SqsKmsKeyBlank, !Ref AWS::NoValue, 86400 ]  # seconds (24 hours)
+      MessageRetentionPeriod: !Ref ErrorQueueMessageRetentionPeriodSecs
       ReceiveMessageWaitTimeSeconds: 20  # long polling (lowest cost)
       VisibilityTimeout: 0  # seconds; dead message retries don't make sense
 
   OperationQueue:
     Type: AWS::SQS::Queue
     Properties:
+      SqsManagedSseEnabled: !If [ SqsKmsKeyBlank, true, false ]
       KmsMasterKeyId:
         Fn::If:
           - SqsKmsKeyBlank
@@ -405,17 +407,14 @@ Resources:
               - !Sub "arn:${AWS::Partition}:kms:${AWS::Region}:${SqsKmsKey}"
               - !Ref SqsKmsKey
       KmsDataKeyReusePeriodSeconds:
-        Fn::If:
-          - SqsKmsKeyBlank
-          - !Ref AWS::NoValue
-          - 86400  # seconds (24 hours)
+        !If [ SqsKmsKeyBlank, !Ref AWS::NoValue, 86400 ]  # seconds (24 hours)
       MaximumMessageSize: !Ref QueueMessageBytesMax
       MessageRetentionPeriod: 720  # seconds (12 minutes)
       ReceiveMessageWaitTimeSeconds: 20  # long polling (lowest cost)
       VisibilityTimeout: !Ref OperationQueueVisibilityTimeoutSecs
       RedrivePolicy:
-        maxReceiveCount: 1  # Rely on boto3 retry logic instead (retry_mode)
-        deadLetterTargetArn: !GetAtt OperationFailedQueue.Arn
+        maxReceiveCount: 10
+        deadLetterTargetArn: !GetAtt ErrorQueue.Arn
       RedriveAllowPolicy:
         redrivePermission: denyAll
 
@@ -502,8 +501,9 @@ Resources:
                 Statement:
                   - Effect: Allow
                     Action:
-                      # https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-key-management.html#receive-from-encrypted-queue
+                      # https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-key-management.html#send-to-encrypted-queue
                       - kms:GenerateDataKey
+                      - kms:Decrypt  # To verify a new data key!
                     Resource: !Sub "arn:${AWS::Partition}:kms:${AWS::Region}:${SqsKmsKey}"
                     Condition:
                       StringEquals: { "kms:ViaService": !Sub "sqs.${AWS::Region}.amazonaws.com" }
@@ -556,11 +556,6 @@ Resources:
                 Resource: !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
                 Condition:
                   StringLike: { "aws:ResourceTag/sched-start": "*" }
-              - Effect: Allow
-                Action: ec2:RebootInstances
-                Resource: !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
-                Condition:
-                  StringLike: { "aws:ResourceTag/sched-reboot": "*" }
               - Effect: Allow
                 Action: ec2:StopInstances
                 Resource: !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
@@ -623,26 +618,6 @@ Resources:
                   StringLike: { "aws:ResourceTag/sched-start": "*" }
               - Effect: Allow
                 Action:
-                  - rds:RebootDBInstance
-                  - rds:RebootDBCluster
-                Resource:
-                  - !Sub "arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:db:*"
-                  - !Sub "arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:cluster:*"
-                Condition:
-                  StringLike: { "aws:ResourceTag/sched-reboot": "*" }
-              - Effect: Allow
-                Action: rds:RebootDBCluster
-                Resource:
-                  - !Sub "arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:db:*"
-              - Effect: Allow
-                Action:
-                  - rds:RebootDBInstance
-                Resource:
-                  - !Sub "arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:db:*"
-                Condition:
-                  StringLike: { "aws:ResourceTag/sched-reboot-failover": "*" }
-              - Effect: Allow
-                Action:
                   - rds:StopDBInstance
                   - rds:StopDBCluster
                 Resource:
@@ -702,14 +677,14 @@ Resources:
                       StringEquals: { "kms:ViaService": !Sub "sqs.${AWS::Region}.amazonaws.com" }
             - !Ref AWS::NoValue
 
-  OperationFailedQueuePol:
+  ErrorQueuePol:
     Type: AWS::SQS::QueuePolicy
     Properties:
-      Queues: [ !Ref OperationFailedQueue ]
+      Queues: [ !Ref ErrorQueue ]
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
-          - Sid: RequireSsl
+          - Sid: RequireTls
             Effect: Deny
             Principal: "*"
             Action: sqs:*
@@ -719,21 +694,27 @@ Resources:
           - Effect: Allow
             Principal: "*"
             Action: sqs:GetQueueAttributes
-            Resource: !GetAtt OperationFailedQueue.Arn
+            Resource: !GetAtt ErrorQueue.Arn
           - Sid: DeadLetterSource
             Effect: Allow
             Principal: "*"
             Action: sqs:SendMessage
-            Resource: !GetAtt OperationFailedQueue.Arn
+            Resource: !GetAtt ErrorQueue.Arn
             Condition:
-              ArnEquals: { aws:SourceArn: !GetAtt OperationQueue.Arn }
+              ArnEquals:
+                "aws:SourceArn":
+                  - !GetAtt FindLambdaFnSched2.Arn
+                  - !GetAtt OperationQueue.Arn
           - Sid: ExclusiveSource
             Effect: Deny
             Principal: "*"
             Action: sqs:SendMessage
-            Resource: !GetAtt OperationFailedQueue.Arn
+            Resource: !GetAtt ErrorQueue.Arn
             Condition:
-              ArnNotEquals: { aws:SourceArn: !GetAtt OperationQueue.Arn }
+              ArnNotEquals:
+                "aws:SourceArn":
+                  - !GetAtt FindLambdaFnSched2.Arn
+                  - !GetAtt OperationQueue.Arn
 
   OperationQueuePol:
     Type: AWS::SQS::QueuePolicy
@@ -786,7 +767,7 @@ Resources:
               - sqs:DeleteMessage
             Resource: !GetAtt OperationQueue.Arn
             Condition:
-              ArnEquals: { aws:SourceArn: !GetAtt OperationFailedQueue.Arn }
+              ArnEquals: { aws:SourceArn: !GetAtt ErrorQueue.Arn }
           - Sid: ExclusiveTargets
             Effect: Deny
             Principal: "*"
@@ -800,7 +781,7 @@ Resources:
                 aws:PrincipalArn:
                   - !GetAtt DoLambdaFnRole.Arn
                 aws:SourceArn:
-                  - !GetAtt OperationFailedQueue.Arn
+                  - !GetAtt ErrorQueue.Arn
 
   FindLambdaFnLogGrp:
     Type: AWS::Logs::LogGroup
@@ -846,7 +827,7 @@ Resources:
       Code:
         ZipFile: |
           #!/usr/bin/env python3
-          """Start, reboot, stop and back up AWS resources tagged with cron schedules
+          """Start, stop and back up AWS resources tagged with cron schedules
 
           github.com/sqlxpert/lights-off-aws  GPLv3  Copyright Paul Marcelin
           """
@@ -1348,7 +1329,6 @@ Resources:
                 ("Instance", ),
                 {
                   ("start", ): {"class": AWSOpMultipleRsrcs},
-                  ("reboot", ): {"class": AWSOpMultipleRsrcs},
                   ("stop", ): {"class": AWSOpMultipleRsrcs},
                   ("hibernate", ): {
                     "class": AWSOpMultipleRsrcs,
@@ -1382,8 +1362,6 @@ Resources:
                 {
                   ("start", ): {},
                   ("stop", ): {},
-                  ("reboot", ): {},
-                  ("reboot", "failover"): {"kwargs_add": {"ForceFailover": True}},
                   ("backup", ): {"class": AWSOpBackUp},
                 },
                 rsrc_id_key_suffix="Identifier",
@@ -1396,7 +1374,6 @@ Resources:
                 {
                   ("start", ): {},
                   ("stop", ): {},
-                  ("reboot", ): {},
                   ("backup", ): {"class": AWSOpBackUp},
                 },
                 rsrc_id_key_suffix="Identifier",
@@ -1523,6 +1500,7 @@ Resources:
         Arn: !GetAtt FindLambdaFn.Arn
         RetryPolicy:
           MaximumRetryAttempts: 0
+        DeadLetterConfig: { Arn: !GetAtt ErrorQueue.Arn }
       State: !If [ EnableTrue, ENABLED, DISABLED ]
 
   DoLambdaFnLogGrp:
@@ -1539,7 +1517,11 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt DoLambdaFnRole.Arn
-      ReservedConcurrentExecutions: !Ref DoLambdaFnReservedConcurrentExecutions
+      ReservedConcurrentExecutions:
+        Fn::If:
+          - DoLambdaFnReservedConcurrentExecutionsOff
+          - !Ref AWS::NoValue
+          - !Ref DoLambdaFnReservedConcurrentExecutions
       Timeout: !Ref DoLambdaFnTimeoutSecs
       MemorySize: !Ref DoLambdaFnMemoryMB
       LoggingConfig:
@@ -1547,6 +1529,7 @@ Resources:
         LogFormat: JSON
         SystemLogLevel: WARN
         ApplicationLogLevel: !Ref LogLevel
+      TracingConfig: { Mode: PassThrough }
       Architectures:
         - arm64
       Runtime: python3.13
@@ -1563,7 +1546,7 @@ Resources:
       Code:
         ZipFile: |
           #!/usr/bin/env python3
-          """Start, reboot, stop and back up AWS resources tagged with cron schedules
+          """Start, stop and back up AWS resources tagged with cron schedules
 
           github.com/sqlxpert/lights-off-aws  GPLv3  Copyright Paul Marcelin
           """
@@ -2065,7 +2048,6 @@ Resources:
                 ("Instance", ),
                 {
                   ("start", ): {"class": AWSOpMultipleRsrcs},
-                  ("reboot", ): {"class": AWSOpMultipleRsrcs},
                   ("stop", ): {"class": AWSOpMultipleRsrcs},
                   ("hibernate", ): {
                     "class": AWSOpMultipleRsrcs,
@@ -2099,8 +2081,6 @@ Resources:
                 {
                   ("start", ): {},
                   ("stop", ): {},
-                  ("reboot", ): {},
-                  ("reboot", "failover"): {"kwargs_add": {"ForceFailover": True}},
                   ("backup", ): {"class": AWSOpBackUp},
                 },
                 rsrc_id_key_suffix="Identifier",
@@ -2113,7 +2093,6 @@ Resources:
                 {
                   ("start", ): {},
                   ("stop", ): {},
-                  ("reboot", ): {},
                   ("backup", ): {"class": AWSOpBackUp},
                 },
                 rsrc_id_key_suffix="Identifier",
@@ -2214,7 +2193,12 @@ Resources:
       EventSourceArn: !GetAtt OperationQueue.Arn
       MaximumBatchingWindowInSeconds: 20  # long polling (lowest cost)
       BatchSize: 1
+      MaximumRetryAttempts: 10
       FunctionName: !GetAtt DoLambdaFn.Arn
       ScalingConfig:
-        MaximumConcurrency: !Ref DoLambdaFnReservedConcurrentExecutions
+        MaximumConcurrency:
+          Fn::If:
+            - DoLambdaFnReservedConcurrentExecutionsOff
+            - 5
+            - !Ref DoLambdaFnReservedConcurrentExecutions
       Enabled: !Ref Enable

--- a/cloudformation/lights_off_aws.yaml
+++ b/cloudformation/lights_off_aws.yaml
@@ -146,12 +146,14 @@ Parameters:
   DoLambdaFnRoleAttachLocalPolicyName:
     Type: String
     Description: >-
-      The name of a customer-managed IAM policy to be attached to the "Do"
+      The name of a customer-managed IAM policy to attach to the "Do"
       function's role. By including "Effect": "Deny" statements, you could,
-      for example, prevent the stopping of production resources.
-      Specify only the name, not the ARN. For a StackSet, the policy must
-      exist, and have exactly the same name, in every target AWS account.
-      Policies are account-wide, not regional. See
+      for example, prevent production resources from being stopped.
+      Specify only the name, not the ARN.
+      For a StackSet, the policy must exist, and have exactly the same name,
+      in every target AWS account.
+      Policies are account-wide, not regional.
+      See
       https://github.com/sqlxpert/lights-off-aws/README.md#security-steps-you-can-take
     Default: ""
 

--- a/cloudformation/lights_off_aws.yaml
+++ b/cloudformation/lights_off_aws.yaml
@@ -2195,7 +2195,6 @@ Resources:
       EventSourceArn: !GetAtt OperationQueue.Arn
       MaximumBatchingWindowInSeconds: 20  # long polling (lowest cost)
       BatchSize: 1
-      MaximumRetryAttempts: 10
       FunctionName: !GetAtt DoLambdaFn.Arn
       ScalingConfig:
         MaximumConcurrency:

--- a/cloudformation/lights_off_aws.yaml
+++ b/cloudformation/lights_off_aws.yaml
@@ -705,7 +705,7 @@ Resources:
             Condition:
               ArnEquals:
                 "aws:SourceArn":
-                  - !GetAtt FindLambdaFnSched2.Arn
+                  - !GetAtt FindLambdaFnSchedGrp.Arn
                   - !GetAtt OperationQueue.Arn
           - Sid: ExclusiveSource
             Effect: Deny
@@ -715,7 +715,7 @@ Resources:
             Condition:
               ArnNotEquals:
                 "aws:SourceArn":
-                  - !GetAtt FindLambdaFnSched2.Arn
+                  - !GetAtt FindLambdaFnSchedGrp.Arn
                   - !GetAtt OperationQueue.Arn
 
   OperationQueuePol:

--- a/cloudformation/lights_off_aws_bonus_cloudformation_example.yaml
+++ b/cloudformation/lights_off_aws_bonus_cloudformation_example.yaml
@@ -41,7 +41,8 @@ Description: |-
 #
 # For many AWS services, you can achieve a least-privilege design with a
 # policy condition:
-#   "StringLike": { "aws:ResourceTag/aws:cloudformation:stack-name": "*KEYWORD*" }
+#   "StringLike":
+#     "aws:ResourceTag/aws:cloudformation:stack-name": "*KEYWORD*"
 # where KEYWORD is a string that you will require in the name of all stacks
 # created using your deployment role, and that you will not allow in the
 # names of any other stacks.

--- a/cloudformation/lights_off_aws_prereq.yaml
+++ b/cloudformation/lights_off_aws_prereq.yaml
@@ -146,25 +146,14 @@ Resources:
               - Effect: Allow
                 Action:
                   - scheduler:CreateScheduleGroup
-                  - scheduler:GetScheduleGroup
                   - scheduler:DeleteScheduleGroup
                   - scheduler:TagResource
                   - scheduler:UntagResource
                 Resource:
                   - !Sub "arn:${AWS::Partition}:scheduler:*:${AWS::AccountId}:schedule-group/${StackNameLike}-*"
-              - Sid: ForDeleteScheduleGroup
-                Effect: Allow
-                Action:
-                  - scheduler:DeleteSchedule
-                  # Possible future requirement:
-                  - scheduler:TagResource
-                  - scheduler:UntagResource
-                Resource:
-                  - !Sub "arn:${AWS::Partition}:scheduler:*:${AWS::AccountId}:schedule/${StackNameLike}-*/*"
               - Effect: Allow
                 Action:
                   - scheduler:CreateSchedule  # Also iam:PassRole
-                  - scheduler:GetSchedule
                   - scheduler:UpdateSchedule  # Also iam:PassRole
                   - scheduler:DeleteSchedule
                   # Possible future requirement:
@@ -179,14 +168,13 @@ Resources:
                   # arn:PARTITION:logs:REGION:ACCOUNT:log-group:GROUP_NAME:log-stream:STREAM_NAME
                   # arn:PARTITION:scheduler:REGION:ACCOUNT:schedule-group/GROUP_NAME
                   # arn:PARTITION:scheduler:REGION:ACCOUNT:schedule/GROUP_NAME/SCHED_NAME
-                  #
-                  # Also: CloudFormation seems to assign temporary SCHED_NAME
-                  # values!
                   - !Sub "arn:${AWS::Partition}:scheduler:*:${AWS::AccountId}:schedule/${StackNameLike}-*/*"
               - Effect: Allow
                 Action:
                   - scheduler:ListScheduleGroups
+                  - scheduler:GetScheduleGroup
                   - scheduler:ListSchedules
+                  - scheduler:GetSchedule
                   - scheduler:ListTagsForResource
                 Resource: "*"
 

--- a/cloudformation/lights_off_aws_prereq.yaml
+++ b/cloudformation/lights_off_aws_prereq.yaml
@@ -179,7 +179,10 @@ Resources:
                   # arn:PARTITION:logs:REGION:ACCOUNT:log-group:GROUP_NAME:log-stream:STREAM_NAME
                   # arn:PARTITION:scheduler:REGION:ACCOUNT:schedule-group/GROUP_NAME
                   # arn:PARTITION:scheduler:REGION:ACCOUNT:schedule/GROUP_NAME/SCHED_NAME
-                  - !Sub "arn:${AWS::Partition}:scheduler:*:${AWS::AccountId}:schedule/${StackNameLike}-*/${StackNameLike}-*"
+                  #
+                  # Also: CloudFormation seems to assign temporary SCHED_NAME
+                  # values!
+                  - !Sub "arn:${AWS::Partition}:scheduler:*:${AWS::AccountId}:schedule/${StackNameLike}-*/*"
               - Effect: Allow
                 Action:
                   - scheduler:ListScheduleGroups

--- a/lights_off_aws.py
+++ b/lights_off_aws.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Start, reboot, stop and back up AWS resources tagged with cron schedules
+"""Start, stop and back up AWS resources tagged with cron schedules
 
 github.com/sqlxpert/lights-off-aws  GPLv3  Copyright Paul Marcelin
 """
@@ -501,7 +501,6 @@ def rsrc_types_init():
       ("Instance", ),
       {
         ("start", ): {"class": AWSOpMultipleRsrcs},
-        ("reboot", ): {"class": AWSOpMultipleRsrcs},
         ("stop", ): {"class": AWSOpMultipleRsrcs},
         ("hibernate", ): {
           "class": AWSOpMultipleRsrcs,
@@ -535,8 +534,6 @@ def rsrc_types_init():
       {
         ("start", ): {},
         ("stop", ): {},
-        ("reboot", ): {},
-        ("reboot", "failover"): {"kwargs_add": {"ForceFailover": True}},
         ("backup", ): {"class": AWSOpBackUp},
       },
       rsrc_id_key_suffix="Identifier",
@@ -549,7 +546,6 @@ def rsrc_types_init():
       {
         ("start", ): {},
         ("stop", ): {},
-        ("reboot", ): {},
         ("backup", ): {"class": AWSOpBackUp},
       },
       rsrc_id_key_suffix="Identifier",

--- a/lights_off_aws.py
+++ b/lights_off_aws.py
@@ -609,7 +609,7 @@ def lambda_handler_do(event, context):  # pylint: disable=unused-argument
         event,
         entry_type="EXPIRED_OP",
         entry_value="Schedule fewer operations per 10-minute cycle or "
-        "increase DoLambdaFnReservedConcurrentExecutions in CloudFormation"
+        "increase DoLambdaFnMaximumConcurrency in CloudFormation"
       )
       raise RuntimeError()
 

--- a/pylintrc
+++ b/pylintrc
@@ -1,4 +1,4 @@
-# Start, reboot, stop and back up AWS resources tagged with cron schedules
+# Start, stop and back up AWS resources tagged with cron schedules
 # github.com/sqlxpert/lights-off-aws/  GPLv3  Copyright Paul Marcelin
 
 [MAIN]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Start, reboot, stop and back up AWS resources tagged with cron schedules
+# Start, stop and back up AWS resources tagged with cron schedules
 # github.com/sqlxpert/lights-off-aws/  GPLv3  Copyright Paul Marcelin
 
 boto3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-# Start, reboot, stop and back up AWS resources tagged with cron schedules
+# Start, stop and back up AWS resources tagged with cron schedules
 # github.com/sqlxpert/lights-off-aws/  GPLv3  Copyright Paul Marcelin
 
 [pycodestyle]


### PR DESCRIPTION
- Removes `sched-reboot` . Not idempotent. Not related to cost savings or to backups. Better served by Systems Manager ( Automation runbook: `AWS-RestartEC2Instance` ).
- Removes default use of reserved concurrency by the "Do" AWS Lambda function. Additional concurrency parameter applies either way.
- Directs EventBridge Schedule errors to the (renamed, multi-source) error queue. Different sources/message types OK because this error queue is not for "redrive".
- Documents a potential setup error re: [Un]reservedConcurrentExecution , affecting new AWS accounts. The "Find" function still needs 1 reserved slot, because of its importance.
- Deployment role: Works around unusual CloudFormation and/orEventBridge Scheduler behavior (tries to reference a schedule in the default group).