### PR TITLE
Quieter RDS/Aurora and CloudFormation idempotence

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,11 +317,11 @@ basic format (example: `20241231T1400Z`).
       steps; this sequence is fundamentally non-atomic. An operation might
       also be repeated due to queue message delivery logic; operations are
       idempotent. If a state change is favorable or an operation is repeated,
-      Lights Off logs HTTPS success responses or expected exceptions
-      (depending on the AWS service) at the INFO level. For RDS database
-      instance start/stop operations, however, Lights Off logs expected
-      exceptions at the ERROR level because it cannot tell whether they
-      represent harmless repetition or actual errors.
+      Lights Off logs success responses or expected exceptions (depending on
+      the AWS service) at the INFO level. For RDS database instance start/stop
+      operations, however, Lights Off logs expected exceptions at the ERROR
+      level because it cannot tell whether they represent harmless repetition
+      or actual errors.
       </details>
 - Check the `ErrorQueue`
   [SQS queue](https://console.aws.amazon.com/sqs/v3/home#/queues)

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Off. Check with your AWS administrator!
 AWS Backup copies resource tags to backups. Lights Off adds `sched-time` to
 indicate when the backup was _scheduled_ to occur, in
 [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations)
-form (example: `2024-12-31T14:00Z`).
+basic format (example: `20241231T1400Z`).
 
 ## On/Off Switch
 
@@ -561,7 +561,7 @@ offering a simple alternative to
 
 ## Dedication
 
-This project is dedicated to ej, Marianne and R&eacute;gis, and to the
+This project is dedicated to ej, Marianne and R&eacute;gis, Ivan, and to the
 wonderful colleagues whom Paul has worked with over the years. Thank you to
 Corey for sharing the original version with the AWS user community, and to Lee
 for suggesting the new name.

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ basic format (example: `20241231T1400Z`).
 - Check the
   [LightsOff CloudWatch log groups](https://console.aws.amazon.com/cloudwatch/home#logsV2:log-groups$3FlogGroupNameFilter$3DLightsOff-).
   - Log entries are JSON objects.
-    - Lights Off includes `"level"`, `"type"` and `"value"` keys.
+    - Lights Off includes `"level"` , `"type"` and `"value"` keys.
     - Other software components may use different keys.
   - For more data, change the `LogLevel` in CloudFormation.
   - Scrutinize log entries at the `ERROR` level.
@@ -311,7 +311,7 @@ basic format (example: `20241231T1400Z`).
       <details>
         <summary>Why the ambiguity?</summary>
       "Find" log:
-      Any entry at the ERROR level is unexpected and requires attention.
+      All entries at the ERROR level are unexpected and require attention.
       "Do" log:
       The state of an AWS resource might change between the "Find" and "Do"
       steps; this sequence is fundamentally non-atomic. An operation might
@@ -321,7 +321,7 @@ basic format (example: `20241231T1400Z`).
       (depending on the AWS service) at the INFO level. For RDS database
       instance start/stop operations, however, Lights Off logs expected
       exceptions at the ERROR level because it cannot tell whether they
-      represenet harmless repetition or actual errors.
+      represent harmless repetition or actual errors.
       </details>
 - Check the `ErrorQueue`
   [SQS queue](https://console.aws.amazon.com/sqs/v3/home#/queues)

--- a/README.md
+++ b/README.md
@@ -310,6 +310,9 @@ basic format (example: `20241231T1400Z`).
     - Otherwise, they _possibly_ require attention.
       <details>
         <summary>Why the ambiguity?</summary>
+      "Find" log:
+      Any entry at the ERROR level is unexpected and requires attention.
+      "Do" log:
       The state of an AWS resource might change between the "Find" and "Do"
       steps; this sequence is fundamentally non-atomic. An operation might
       also be repeated due to queue message delivery logic; operations are

--- a/README.md
+++ b/README.md
@@ -309,15 +309,15 @@ basic format (example: `20241231T1400Z`).
       exceptions that _definitely_ require attention.
     - Otherwise, they _possibly_ require attention.
       <details>
-        <summary>Why the uncertainty?</summary>
+        <summary>Why the ambiguity?</summary>
       The state of an AWS resource might change between the "Find" and "Do"
       steps; this sequence is fundamentally non-atomic. An operation might
       also be repeated due to queue message delivery logic; operations are
       idempotent. If a state change is favorable or an operation is repeated,
       Lights Off logs HTTPS success responses or expected exceptions
-      (depending on the AWS service) at the `INFO` level. For _RDS database
-      instance_ start/stop operations, however, Lights Off logs expected
-      exceptions at the `ERROR` level because it cannot tell whether they
+      (depending on the AWS service) at the INFO level. For RDS database
+      instance start/stop operations, however, Lights Off logs expected
+      exceptions at the ERROR level because it cannot tell whether they
       represenet harmless repetition or actual errors.
       </details>
 - Check the `ErrorQueue`

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Ever forget to turn the lights off? Now you can:
 _Most of all, this solution is lightweight. Not counting blanks, comments, or
 tests, AWS's
 [Instance Scheduler](https://github.com/aws-solutions/instance-scheduler-on-aws)
-has over 9,500 lines of Python! At under 600 lines of Python, Lights Off is
+has over 9,500 lines of Python! At about 600 lines of Python, Lights Off is
 easy to understand, maintain, and extend._
 
 Jump to:
@@ -300,9 +300,17 @@ basic format (example: `20241231T1400Z`).
 
 - Check the
   [LightsOff CloudWatch log groups](https://console.aws.amazon.com/cloudwatch/home#logsV2:log-groups$3FlogGroupNameFilter$3DLightsOff-).
-  - Log entries are JSON objects. Entries from Lights Off include `"level"`,
-    `"type"` and `"value"` keys.
+  - Log entries are JSON objects. Lights Off includes `"level"`, `"type"` and
+    `"value"` keys in its custom log entries. (Other software components may
+    use different keys.)
   - For more data, change the `LogLevel` in CloudFormation.
+  - Operations are idempotent. Lights Off logs the results of most harmless,
+    repeated AWS API calls (depending on the AWS service, either HTTPS success
+    responses, or expected exceptions) at the `INFO` level. For RDS database
+    _instance_ start/stop operations, however, Lights Off logs expected
+    exceptions at the `ERROR` level; these may represent harmless repetition,
+    or errors that require attention.
+  - Lights Off logs unexpected (uncaught) exceptions at the `ERROR` level.
 - Check the `ErrorQueue`
   [SQS queue](https://console.aws.amazon.com/sqs/v3/home#/queues)
   for undeliverable "Find" and "Do" events.
@@ -555,9 +563,9 @@ offering a simple alternative to
 
 |Year|AWS Lambda Python Lines|Core CloudFormation YAML Lines|
 |:---:|:---:|:---:|
-|2017| &asymp; 775|&asymp; 2,140|
+|2017|&asymp; 775|&asymp; 2,140|
 |2022|630|800 &check;|
-|2025|550 &check;|940|
+|2025|600 &check;|940|
 
 ## Dedication
 

--- a/cloudformation/lights_off_aws.yaml
+++ b/cloudformation/lights_off_aws.yaml
@@ -995,6 +995,43 @@ Resources:
               log(entry_type, entry_value, log_level)
 
 
+          def assess_op_except(svc, op_method_name, svc_client, misc_except):
+            """Take an operation and an exception, return log level and recoverability
+            """
+            verb = op_method_name.split("_")[0]
+            misc_except_str = str(misc_except)
+
+            log_level = logging.INFO
+            recoverable = True
+
+            match (svc, misc_except):
+
+              case ("cloudformation", botocore.exceptions.ClientError()) if (
+                "No updates are to be performed." in misc_except_str
+              ):
+                pass  # Recent, identical external update_stack
+
+              case ("rds", svc_client.exceptions.InvalidDBClusterStateFault()) if (
+                ((verb == "start") and "is in available" in misc_except_str)
+                or f"is in {verb}" in misc_except_str
+              ):
+                pass
+                # start_db_cluster when "in available[ state]" or "in start[ing state]"
+                # stop__db_cluster when "in stop[ped state]"   or "in stop[ping state]"
+
+              case ("rds", svc_client.exceptions.InvalidDBInstanceStateFault()):
+                log_level = logging.ERROR
+                # Idempotent start_db_instance or stop_db_instance , or an actual error
+                # (The available exception does not give the present, invalid state for
+                # us to check, so log an error but do not raise.)
+
+              case _:
+                log_level = logging.ERROR
+                recoverable = False
+
+            return (log_level, recoverable)
+
+
           def tag_key_join(tag_key_words):
             """Take a tuple of strings, add a prefix, join, and return a tag key
             """
@@ -1291,7 +1328,10 @@ Resources:
 
               # Use of final template instead of original makes this incompatible with
               # CloudFormation "transforms". describe_stacks does not return templates.
-              self.kwargs_add["UsePreviousTemplate"] = True
+              self.kwargs_add.update({
+                "UsePreviousTemplate": True,
+                "RetainExceptOnCreate": True,
+              })
 
               # Use previous parameter values, except for:
               #                          Param  Value
@@ -1310,30 +1350,40 @@ Resources:
               op_kwargs_out = {}
               params_out = []
 
-              for param in rsrc.get("Parameters", []):
+              if rsrc.get("StackStatus") in (
+                "UPDATE_COMPLETE",
+                "CREATE_COMPLETE",
+              ):
+                for param in rsrc.get("Parameters", []):
+                  param_key = param["ParameterKey"]
+                  param_out = {
+                    "ParameterKey": param_key,
+                    "UsePreviousValue": True,
+                  }
 
-                param_key = param["ParameterKey"]
-                param_out = {
-                  "ParameterKey": param_key,
-                  "UsePreviousValue": True,
-                }
+                  if param_key == self.changing_param_key:
+                    if param.get("ParameterValue") == self.changing_param_value_out:
+                      break
 
-                if param_key == self.changing_param_key:
-                  if param.get("ParameterValue") == self.changing_param_value_out:
-                    break
+                    # One time, if changing_param is present and not already up-to-date
+                    param_out.update({
+                      "UsePreviousValue": False,
+                      "ParameterValue": self.changing_param_value_out,
+                    })
+                    op_kwargs_out = super().op_kwargs(rsrc, cycle_start_str)
+                    op_kwargs_out.update({
+                      "ClientRequestToken": f"{self.tag_key}-{cycle_start_str}",
+                      "Parameters": params_out,  # Continue updating dict in-place
+                    })
+                    capabilities = rsrc.get("Capabilities")
+                    if capabilities:
+                      op_kwargs_out["Capabilities"] = capabilities
 
-                  # Never, if changing_param is absent or up-to-date; once at most...
-                  param_out.update({
-                    "UsePreviousValue": False,
-                    "ParameterValue": self.changing_param_value_out,
-                  })
-                  op_kwargs_out = super().op_kwargs(rsrc, cycle_start_str)
-                  op_kwargs_out["Parameters"] = params_out  # Continue updating in-place
-                  capabilities = rsrc.get("Capabilities")
-                  if capabilities:
-                    op_kwargs_out["Capabilities"] = capabilities
+                  params_out.append(param_out)
 
-                params_out.append(param_out)
+              else:
+                log("ERROR", "STACK_STATUS_IRREGULAR", logging.ERROR)
+                log("AWS_RESPONSE_PART", rsrc, logging.ERROR)
 
               return op_kwargs_out
 
@@ -1473,7 +1523,10 @@ Resources:
             (cycle_start, cycle_cutoff) = cycle_start_end(
               datetime.datetime.now(datetime.timezone.utc)
             )
-            cycle_start_str = cycle_start.strftime("%Y-%m-%dT%H:%MZ")
+
+            # ISO 8601 basic, no puctuation (downstream requirement)
+            cycle_start_str = cycle_start.strftime("%Y%m%dT%H%MZ")
+
             cycle_cutoff_epoch_str = str(int(cycle_cutoff.timestamp()))
             sched_regexp = re.compile(
               cycle_start.strftime(SCHED_REGEXP_STRFTIME_FMT), re.VERBOSE
@@ -1514,18 +1567,25 @@ Resources:
 
               svc = msg_attr_str_decode(msg, "svc")
               op_method_name = msg_attr_str_decode(msg, "op_method_name")
+              svc_client = svc_client_get(svc)
               try:
                 op_kwargs = json.loads(msg["body"])
-                op_method = getattr(svc_client_get(svc), op_method_name)
+                op_method = getattr(svc_client, op_method_name)
                 resp = op_method(**op_kwargs)
-              except Exception as misc_except:
-                op_log(event, entry_type="EXCEPTION", entry_value=misc_except)
-                raise
-              if boto3_success(resp):
-                op_log(event, resp=resp, log_level=logging.INFO)
+              except Exception as misc_except:  # pylint: disable=broad-exception-caught
+                (log_level, recoverable) = assess_op_except(
+                  svc, op_method_name, svc_client, misc_except
+                )
+                op_log(
+                  event,
+                  entry_type="EXCEPTION",
+                  entry_value=misc_except,
+                  log_level=log_level
+                )
+                if not recoverable:
+                  raise
               else:
-                op_log(event, resp=resp)
-                raise RuntimeError()
+                op_log(event, resp=resp, log_level=logging.INFO)
         # ZIPFILE_END
 
   FindLambdaFnSchedGrp:
@@ -1758,6 +1818,43 @@ Resources:
               log(entry_type, entry_value, log_level)
 
 
+          def assess_op_except(svc, op_method_name, svc_client, misc_except):
+            """Take an operation and an exception, return log level and recoverability
+            """
+            verb = op_method_name.split("_")[0]
+            misc_except_str = str(misc_except)
+
+            log_level = logging.INFO
+            recoverable = True
+
+            match (svc, misc_except):
+
+              case ("cloudformation", botocore.exceptions.ClientError()) if (
+                "No updates are to be performed." in misc_except_str
+              ):
+                pass  # Recent, identical external update_stack
+
+              case ("rds", svc_client.exceptions.InvalidDBClusterStateFault()) if (
+                ((verb == "start") and "is in available" in misc_except_str)
+                or f"is in {verb}" in misc_except_str
+              ):
+                pass
+                # start_db_cluster when "in available[ state]" or "in start[ing state]"
+                # stop__db_cluster when "in stop[ped state]"   or "in stop[ping state]"
+
+              case ("rds", svc_client.exceptions.InvalidDBInstanceStateFault()):
+                log_level = logging.ERROR
+                # Idempotent start_db_instance or stop_db_instance , or an actual error
+                # (The available exception does not give the present, invalid state for
+                # us to check, so log an error but do not raise.)
+
+              case _:
+                log_level = logging.ERROR
+                recoverable = False
+
+            return (log_level, recoverable)
+
+
           def tag_key_join(tag_key_words):
             """Take a tuple of strings, add a prefix, join, and return a tag key
             """
@@ -2054,7 +2151,10 @@ Resources:
 
               # Use of final template instead of original makes this incompatible with
               # CloudFormation "transforms". describe_stacks does not return templates.
-              self.kwargs_add["UsePreviousTemplate"] = True
+              self.kwargs_add.update({
+                "UsePreviousTemplate": True,
+                "RetainExceptOnCreate": True,
+              })
 
               # Use previous parameter values, except for:
               #                          Param  Value
@@ -2073,30 +2173,40 @@ Resources:
               op_kwargs_out = {}
               params_out = []
 
-              for param in rsrc.get("Parameters", []):
+              if rsrc.get("StackStatus") in (
+                "UPDATE_COMPLETE",
+                "CREATE_COMPLETE",
+              ):
+                for param in rsrc.get("Parameters", []):
+                  param_key = param["ParameterKey"]
+                  param_out = {
+                    "ParameterKey": param_key,
+                    "UsePreviousValue": True,
+                  }
 
-                param_key = param["ParameterKey"]
-                param_out = {
-                  "ParameterKey": param_key,
-                  "UsePreviousValue": True,
-                }
+                  if param_key == self.changing_param_key:
+                    if param.get("ParameterValue") == self.changing_param_value_out:
+                      break
 
-                if param_key == self.changing_param_key:
-                  if param.get("ParameterValue") == self.changing_param_value_out:
-                    break
+                    # One time, if changing_param is present and not already up-to-date
+                    param_out.update({
+                      "UsePreviousValue": False,
+                      "ParameterValue": self.changing_param_value_out,
+                    })
+                    op_kwargs_out = super().op_kwargs(rsrc, cycle_start_str)
+                    op_kwargs_out.update({
+                      "ClientRequestToken": f"{self.tag_key}-{cycle_start_str}",
+                      "Parameters": params_out,  # Continue updating dict in-place
+                    })
+                    capabilities = rsrc.get("Capabilities")
+                    if capabilities:
+                      op_kwargs_out["Capabilities"] = capabilities
 
-                  # Never, if changing_param is absent or up-to-date; once at most...
-                  param_out.update({
-                    "UsePreviousValue": False,
-                    "ParameterValue": self.changing_param_value_out,
-                  })
-                  op_kwargs_out = super().op_kwargs(rsrc, cycle_start_str)
-                  op_kwargs_out["Parameters"] = params_out  # Continue updating in-place
-                  capabilities = rsrc.get("Capabilities")
-                  if capabilities:
-                    op_kwargs_out["Capabilities"] = capabilities
+                  params_out.append(param_out)
 
-                params_out.append(param_out)
+              else:
+                log("ERROR", "STACK_STATUS_IRREGULAR", logging.ERROR)
+                log("AWS_RESPONSE_PART", rsrc, logging.ERROR)
 
               return op_kwargs_out
 
@@ -2236,7 +2346,10 @@ Resources:
             (cycle_start, cycle_cutoff) = cycle_start_end(
               datetime.datetime.now(datetime.timezone.utc)
             )
-            cycle_start_str = cycle_start.strftime("%Y-%m-%dT%H:%MZ")
+
+            # ISO 8601 basic, no puctuation (downstream requirement)
+            cycle_start_str = cycle_start.strftime("%Y%m%dT%H%MZ")
+
             cycle_cutoff_epoch_str = str(int(cycle_cutoff.timestamp()))
             sched_regexp = re.compile(
               cycle_start.strftime(SCHED_REGEXP_STRFTIME_FMT), re.VERBOSE
@@ -2277,18 +2390,25 @@ Resources:
 
               svc = msg_attr_str_decode(msg, "svc")
               op_method_name = msg_attr_str_decode(msg, "op_method_name")
+              svc_client = svc_client_get(svc)
               try:
                 op_kwargs = json.loads(msg["body"])
-                op_method = getattr(svc_client_get(svc), op_method_name)
+                op_method = getattr(svc_client, op_method_name)
                 resp = op_method(**op_kwargs)
-              except Exception as misc_except:
-                op_log(event, entry_type="EXCEPTION", entry_value=misc_except)
-                raise
-              if boto3_success(resp):
-                op_log(event, resp=resp, log_level=logging.INFO)
+              except Exception as misc_except:  # pylint: disable=broad-exception-caught
+                (log_level, recoverable) = assess_op_except(
+                  svc, op_method_name, svc_client, misc_except
+                )
+                op_log(
+                  event,
+                  entry_type="EXCEPTION",
+                  entry_value=misc_except,
+                  log_level=log_level
+                )
+                if not recoverable:
+                  raise
               else:
-                op_log(event, resp=resp)
-                raise RuntimeError()
+                op_log(event, resp=resp, log_level=logging.INFO)
         # ZIPFILE_END
 
   # Administrator should block other invocation of this AWS Lambda function

--- a/cloudformation/lights_off_aws.yaml
+++ b/cloudformation/lights_off_aws.yaml
@@ -984,8 +984,8 @@ Resources:
               log(entry_type, entry_value, log_level)
 
 
-          def assess_op_client_err(svc, op_method_name, client_err_except):
-            """Take a ClientError exception, return log level and recoverability
+          def assess_op_except(svc, op_method_name, misc_except):
+            """Take an operation and an exception, return log level and recoverability
 
             botocore.exceptions.ClientError is general but statically-defined, making
             comparison easier, in a multi-service context, than for service-specific but
@@ -995,36 +995,36 @@ Resources:
 
             https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html#parsing-error-responses-and-catching-exceptions-from-aws-services
             """
-            verb = op_method_name.split("_")[0]
-            err_dict = getattr(client_err_except, "response", {}).get("Error", {})
-            err_msg = err_dict.get("Message")
+            log_level = logging.ERROR
+            recoverable = False
 
-            log_level = logging.INFO
-            recoverable = True
+            if isinstance(misc_except, botocore.exceptions.ClientError):
+              verb = op_method_name.split("_")[0]
+              err_dict = getattr(misc_except, "response", {}).get("Error", {})
+              err_msg = err_dict.get("Message")
 
-            match (svc, err_dict.get("Code")):
+              match (svc, err_dict.get("Code")):
 
-              case ("cloudformation", "ValidationError") if (
-                "No updates are to be performed." == err_msg
-              ):
-                pass  # Recent, identical external update_stack
+                case ("cloudformation", "ValidationError") if (
+                  "No updates are to be performed." == err_msg
+                ):
+                  log_level = logging.INFO
+                  recoverable = True
+                  # Recent, identical external update_stack
 
-              case ("rds", "InvalidDBClusterStateFault") if (
-                ((verb == "start") and "is in available" in err_msg)
-                or f"is in {verb}" in err_msg
-              ):
-                pass
-                # start_db_cluster when "in available[ state]" or "in start[ing state]"
-                # stop__db_cluster when "in stop[ped state]"   or "in stop[ping state]"
+                case ("rds", "InvalidDBClusterStateFault") if (
+                  ((verb == "start") and "is in available" in err_msg)
+                  or f"is in {verb}" in err_msg
+                ):
+                  log_level = logging.INFO
+                  recoverable = True
+                  # start_db_cluster when "in available[ state]" or "in start[ing state]"
+                  # stop__db_cluster when "in stop[ped state]"   or "in stop[ping state]"
 
-              case ("rds", "InvalidDBInstanceState"):  # Fault suffix is missing here!
-                log_level = logging.ERROR
-                # Can't decide between idempotent start_db_instance / stop_db_instance
-                # or error, because message does not reveal the current, invalid state.
-
-              case _:
-                log_level = logging.ERROR
-                recoverable = False
+                case ("rds", "InvalidDBInstanceState"):  # Fault suffix is missing here!
+                  recoverable = True
+                  # Can't decide between idempotent start_db_instance / stop_db_instance
+                  # or error, because message does not reveal the current, invalid state.
 
             return (log_level, recoverable)
 
@@ -1575,14 +1575,14 @@ Resources:
                 op_kwargs = json.loads(msg["body"])
                 op_method = getattr(svc_client, op_method_name)
                 resp = op_method(**op_kwargs)
-              except botocore.exceptions.ClientError as client_err_except:
-                (log_level, recoverable) = assess_op_client_err(
-                  svc, op_method_name, client_err_except
+              except Exception as misc_except:  # pylint: disable=broad-exception-caught
+                (log_level, recoverable) = assess_op_except(
+                  svc, op_method_name, misc_except
                 )
                 op_log(
                   event,
                   entry_type="EXCEPTION",
-                  entry_value=client_err_except,
+                  entry_value=misc_except,
                   log_level=log_level
                 )
                 if not recoverable:
@@ -1810,8 +1810,8 @@ Resources:
               log(entry_type, entry_value, log_level)
 
 
-          def assess_op_client_err(svc, op_method_name, client_err_except):
-            """Take a ClientError exception, return log level and recoverability
+          def assess_op_except(svc, op_method_name, misc_except):
+            """Take an operation and an exception, return log level and recoverability
 
             botocore.exceptions.ClientError is general but statically-defined, making
             comparison easier, in a multi-service context, than for service-specific but
@@ -1821,36 +1821,36 @@ Resources:
 
             https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html#parsing-error-responses-and-catching-exceptions-from-aws-services
             """
-            verb = op_method_name.split("_")[0]
-            err_dict = getattr(client_err_except, "response", {}).get("Error", {})
-            err_msg = err_dict.get("Message")
+            log_level = logging.ERROR
+            recoverable = False
 
-            log_level = logging.INFO
-            recoverable = True
+            if isinstance(misc_except, botocore.exceptions.ClientError):
+              verb = op_method_name.split("_")[0]
+              err_dict = getattr(misc_except, "response", {}).get("Error", {})
+              err_msg = err_dict.get("Message")
 
-            match (svc, err_dict.get("Code")):
+              match (svc, err_dict.get("Code")):
 
-              case ("cloudformation", "ValidationError") if (
-                "No updates are to be performed." == err_msg
-              ):
-                pass  # Recent, identical external update_stack
+                case ("cloudformation", "ValidationError") if (
+                  "No updates are to be performed." == err_msg
+                ):
+                  log_level = logging.INFO
+                  recoverable = True
+                  # Recent, identical external update_stack
 
-              case ("rds", "InvalidDBClusterStateFault") if (
-                ((verb == "start") and "is in available" in err_msg)
-                or f"is in {verb}" in err_msg
-              ):
-                pass
-                # start_db_cluster when "in available[ state]" or "in start[ing state]"
-                # stop__db_cluster when "in stop[ped state]"   or "in stop[ping state]"
+                case ("rds", "InvalidDBClusterStateFault") if (
+                  ((verb == "start") and "is in available" in err_msg)
+                  or f"is in {verb}" in err_msg
+                ):
+                  log_level = logging.INFO
+                  recoverable = True
+                  # start_db_cluster when "in available[ state]" or "in start[ing state]"
+                  # stop__db_cluster when "in stop[ped state]"   or "in stop[ping state]"
 
-              case ("rds", "InvalidDBInstanceState"):  # Fault suffix is missing here!
-                log_level = logging.ERROR
-                # Can't decide between idempotent start_db_instance / stop_db_instance
-                # or error, because message does not reveal the current, invalid state.
-
-              case _:
-                log_level = logging.ERROR
-                recoverable = False
+                case ("rds", "InvalidDBInstanceState"):  # Fault suffix is missing here!
+                  recoverable = True
+                  # Can't decide between idempotent start_db_instance / stop_db_instance
+                  # or error, because message does not reveal the current, invalid state.
 
             return (log_level, recoverable)
 
@@ -2401,14 +2401,14 @@ Resources:
                 op_kwargs = json.loads(msg["body"])
                 op_method = getattr(svc_client, op_method_name)
                 resp = op_method(**op_kwargs)
-              except botocore.exceptions.ClientError as client_err_except:
-                (log_level, recoverable) = assess_op_client_err(
-                  svc, op_method_name, client_err_except
+              except Exception as misc_except:  # pylint: disable=broad-exception-caught
+                (log_level, recoverable) = assess_op_except(
+                  svc, op_method_name, misc_except
                 )
                 op_log(
                   event,
                   entry_type="EXCEPTION",
-                  entry_value=client_err_except,
+                  entry_value=misc_except,
                   log_level=log_level
                 )
                 if not recoverable:

--- a/cloudformation/lights_off_aws.yaml
+++ b/cloudformation/lights_off_aws.yaml
@@ -1570,10 +1570,9 @@ Resources:
 
               svc = msg_attr_str_decode(msg, "svc")
               op_method_name = msg_attr_str_decode(msg, "op_method_name")
-              svc_client = svc_client_get(svc)
               try:
                 op_kwargs = json.loads(msg["body"])
-                op_method = getattr(svc_client, op_method_name)
+                op_method = getattr(svc_client_get(svc), op_method_name)
                 resp = op_method(**op_kwargs)
               except Exception as misc_except:  # pylint: disable=broad-exception-caught
                 (log_level, recoverable) = assess_op_except(
@@ -2396,10 +2395,9 @@ Resources:
 
               svc = msg_attr_str_decode(msg, "svc")
               op_method_name = msg_attr_str_decode(msg, "op_method_name")
-              svc_client = svc_client_get(svc)
               try:
                 op_kwargs = json.loads(msg["body"])
-                op_method = getattr(svc_client, op_method_name)
+                op_method = getattr(svc_client_get(svc), op_method_name)
                 resp = op_method(**op_kwargs)
               except Exception as misc_except:  # pylint: disable=broad-exception-caught
                 (log_level, recoverable) = assess_op_except(

--- a/cloudformation/lights_off_aws.yaml
+++ b/cloudformation/lights_off_aws.yaml
@@ -957,27 +957,16 @@ Resources:
             )
 
 
-          def boto3_success(resp):
-            """Take a boto3 response, return True if result was success
-
-            Success means an AWS operation has started, not necessarily that it has
-            completed. For example, it may take hours for a backup to become available.
-            Checking completion is left to other tools.
-            """
-            return (
-              isinstance(resp, dict)
-              and isinstance(resp.get("ResponseMetadata"), dict)
-              and (resp["ResponseMetadata"].get("HTTPStatusCode") == 200)
-            )
-
-
-          def sqs_send_log(cycle_start_str, send_kwargs, entry_type, entry_value):
+          def sqs_send_log(
+            cycle_start_str,
+            send_kwargs,
+            entry_type,
+            entry_value,
+            log_level=logging.ERROR
+          ):
             """Log scheduled start time (on error), SQS send_message content, outcome
             """
-            if (entry_type == "AWS_RESPONSE") and boto3_success(entry_value):
-              log_level = logging.INFO
-            else:
-              log_level = logging.ERROR
+            if log_level == logging.ERROR:
               log("START", cycle_start_str, log_level)
             log("SQS_SEND", send_kwargs, log_level)
             log(entry_type, entry_value, log_level)
@@ -995,35 +984,43 @@ Resources:
               log(entry_type, entry_value, log_level)
 
 
-          def assess_op_except(svc, op_method_name, svc_client, misc_except):
-            """Take an operation and an exception, return log level and recoverability
+          def assess_op_client_err(svc, op_method_name, client_err_except):
+            """Take a ClientError exception, return log level and recoverability
+
+            botocore.exceptions.ClientError is general but statically-defined, making
+            comparison easier, in a multi-service context, than for service-specific but
+            dynamically-defined exceptions like
+            boto3.Client("rds").exceptions.InvalidDBClusterStateFault and
+            boto3.Client("rds").exceptions.InvalidDBInstanceStateFault
+
+            https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html#parsing-error-responses-and-catching-exceptions-from-aws-services
             """
             verb = op_method_name.split("_")[0]
-            misc_except_str = str(misc_except)
+            err_dict = getattr(client_err_except, "response", {}).get("Error", {})
+            err_msg = err_dict.get("Message")
 
             log_level = logging.INFO
             recoverable = True
 
-            match (svc, misc_except):
+            match (svc, err_dict.get("Code")):
 
-              case ("cloudformation", botocore.exceptions.ClientError()) if (
-                "No updates are to be performed." in misc_except_str
+              case ("cloudformation", "ValidationError") if (
+                "No updates are to be performed." == err_msg
               ):
                 pass  # Recent, identical external update_stack
 
-              case ("rds", svc_client.exceptions.InvalidDBClusterStateFault()) if (
-                ((verb == "start") and "is in available" in misc_except_str)
-                or f"is in {verb}" in misc_except_str
+              case ("rds", "InvalidDBClusterStateFault") if (
+                ((verb == "start") and "is in available" in err_msg)
+                or f"is in {verb}" in err_msg
               ):
                 pass
                 # start_db_cluster when "in available[ state]" or "in start[ing state]"
                 # stop__db_cluster when "in stop[ped state]"   or "in stop[ping state]"
 
-              case ("rds", svc_client.exceptions.InvalidDBInstanceStateFault()):
+              case ("rds", "InvalidDBInstanceState"):  # Fault suffix is missing here!
                 log_level = logging.ERROR
-                # Idempotent start_db_instance or stop_db_instance , or an actual error
-                # (The available exception does not give the present, invalid state for
-                # us to check, so log an error but do not raise.)
+                # Can't decide between idempotent start_db_instance / stop_db_instance
+                # or error, because message does not reveal the current, invalid state.
 
               case _:
                 log_level = logging.ERROR
@@ -1297,7 +1294,13 @@ Resources:
                   sqs_send_log(cycle_start_str, send_kwargs, "EXCEPTION", misc_except)
                   raise  # In error cases other than this, log 1 failed send but move on
                 else:
-                  sqs_send_log(cycle_start_str, send_kwargs, "AWS_RESPONSE", sqs_resp)
+                  sqs_send_log(
+                    cycle_start_str,
+                    send_kwargs,
+                    "AWS_RESPONSE",
+                    sqs_resp,
+                    log_level=logging.INFO
+                  )
 
             def __str__(self):
               return " ".join([
@@ -1572,14 +1575,14 @@ Resources:
                 op_kwargs = json.loads(msg["body"])
                 op_method = getattr(svc_client, op_method_name)
                 resp = op_method(**op_kwargs)
-              except Exception as misc_except:  # pylint: disable=broad-exception-caught
-                (log_level, recoverable) = assess_op_except(
-                  svc, op_method_name, svc_client, misc_except
+              except botocore.exceptions.ClientError as client_err_except:
+                (log_level, recoverable) = assess_op_client_err(
+                  svc, op_method_name, client_err_except
                 )
                 op_log(
                   event,
                   entry_type="EXCEPTION",
-                  entry_value=misc_except,
+                  entry_value=client_err_except,
                   log_level=log_level
                 )
                 if not recoverable:
@@ -1780,27 +1783,16 @@ Resources:
             )
 
 
-          def boto3_success(resp):
-            """Take a boto3 response, return True if result was success
-
-            Success means an AWS operation has started, not necessarily that it has
-            completed. For example, it may take hours for a backup to become available.
-            Checking completion is left to other tools.
-            """
-            return (
-              isinstance(resp, dict)
-              and isinstance(resp.get("ResponseMetadata"), dict)
-              and (resp["ResponseMetadata"].get("HTTPStatusCode") == 200)
-            )
-
-
-          def sqs_send_log(cycle_start_str, send_kwargs, entry_type, entry_value):
+          def sqs_send_log(
+            cycle_start_str,
+            send_kwargs,
+            entry_type,
+            entry_value,
+            log_level=logging.ERROR
+          ):
             """Log scheduled start time (on error), SQS send_message content, outcome
             """
-            if (entry_type == "AWS_RESPONSE") and boto3_success(entry_value):
-              log_level = logging.INFO
-            else:
-              log_level = logging.ERROR
+            if log_level == logging.ERROR:
               log("START", cycle_start_str, log_level)
             log("SQS_SEND", send_kwargs, log_level)
             log(entry_type, entry_value, log_level)
@@ -1818,35 +1810,43 @@ Resources:
               log(entry_type, entry_value, log_level)
 
 
-          def assess_op_except(svc, op_method_name, svc_client, misc_except):
-            """Take an operation and an exception, return log level and recoverability
+          def assess_op_client_err(svc, op_method_name, client_err_except):
+            """Take a ClientError exception, return log level and recoverability
+
+            botocore.exceptions.ClientError is general but statically-defined, making
+            comparison easier, in a multi-service context, than for service-specific but
+            dynamically-defined exceptions like
+            boto3.Client("rds").exceptions.InvalidDBClusterStateFault and
+            boto3.Client("rds").exceptions.InvalidDBInstanceStateFault
+
+            https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html#parsing-error-responses-and-catching-exceptions-from-aws-services
             """
             verb = op_method_name.split("_")[0]
-            misc_except_str = str(misc_except)
+            err_dict = getattr(client_err_except, "response", {}).get("Error", {})
+            err_msg = err_dict.get("Message")
 
             log_level = logging.INFO
             recoverable = True
 
-            match (svc, misc_except):
+            match (svc, err_dict.get("Code")):
 
-              case ("cloudformation", botocore.exceptions.ClientError()) if (
-                "No updates are to be performed." in misc_except_str
+              case ("cloudformation", "ValidationError") if (
+                "No updates are to be performed." == err_msg
               ):
                 pass  # Recent, identical external update_stack
 
-              case ("rds", svc_client.exceptions.InvalidDBClusterStateFault()) if (
-                ((verb == "start") and "is in available" in misc_except_str)
-                or f"is in {verb}" in misc_except_str
+              case ("rds", "InvalidDBClusterStateFault") if (
+                ((verb == "start") and "is in available" in err_msg)
+                or f"is in {verb}" in err_msg
               ):
                 pass
                 # start_db_cluster when "in available[ state]" or "in start[ing state]"
                 # stop__db_cluster when "in stop[ped state]"   or "in stop[ping state]"
 
-              case ("rds", svc_client.exceptions.InvalidDBInstanceStateFault()):
+              case ("rds", "InvalidDBInstanceState"):  # Fault suffix is missing here!
                 log_level = logging.ERROR
-                # Idempotent start_db_instance or stop_db_instance , or an actual error
-                # (The available exception does not give the present, invalid state for
-                # us to check, so log an error but do not raise.)
+                # Can't decide between idempotent start_db_instance / stop_db_instance
+                # or error, because message does not reveal the current, invalid state.
 
               case _:
                 log_level = logging.ERROR
@@ -2120,7 +2120,13 @@ Resources:
                   sqs_send_log(cycle_start_str, send_kwargs, "EXCEPTION", misc_except)
                   raise  # In error cases other than this, log 1 failed send but move on
                 else:
-                  sqs_send_log(cycle_start_str, send_kwargs, "AWS_RESPONSE", sqs_resp)
+                  sqs_send_log(
+                    cycle_start_str,
+                    send_kwargs,
+                    "AWS_RESPONSE",
+                    sqs_resp,
+                    log_level=logging.INFO
+                  )
 
             def __str__(self):
               return " ".join([
@@ -2395,14 +2401,14 @@ Resources:
                 op_kwargs = json.loads(msg["body"])
                 op_method = getattr(svc_client, op_method_name)
                 resp = op_method(**op_kwargs)
-              except Exception as misc_except:  # pylint: disable=broad-exception-caught
-                (log_level, recoverable) = assess_op_except(
-                  svc, op_method_name, svc_client, misc_except
+              except botocore.exceptions.ClientError as client_err_except:
+                (log_level, recoverable) = assess_op_client_err(
+                  svc, op_method_name, client_err_except
                 )
                 op_log(
                   event,
                   entry_type="EXCEPTION",
-                  entry_value=misc_except,
+                  entry_value=client_err_except,
                   log_level=log_level
                 )
                 if not recoverable:

--- a/lights_off_aws.py
+++ b/lights_off_aws.py
@@ -697,10 +697,9 @@ def lambda_handler_do(event, context):  # pylint: disable=unused-argument
 
     svc = msg_attr_str_decode(msg, "svc")
     op_method_name = msg_attr_str_decode(msg, "op_method_name")
-    svc_client = svc_client_get(svc)
     try:
       op_kwargs = json.loads(msg["body"])
-      op_method = getattr(svc_client, op_method_name)
+      op_method = getattr(svc_client_get(svc), op_method_name)
       resp = op_method(**op_kwargs)
     except Exception as misc_except:  # pylint: disable=broad-exception-caught
       (log_level, recoverable) = assess_op_except(

--- a/lights_off_aws.py
+++ b/lights_off_aws.py
@@ -111,8 +111,8 @@ def op_log(
     log(entry_type, entry_value, log_level)
 
 
-def assess_op_client_err(svc, op_method_name, client_err_except):
-  """Take a ClientError exception, return log level and recoverability
+def assess_op_except(svc, op_method_name, misc_except):
+  """Take an operation and an exception, return log level and recoverability
 
   botocore.exceptions.ClientError is general but statically-defined, making
   comparison easier, in a multi-service context, than for service-specific but
@@ -122,36 +122,36 @@ def assess_op_client_err(svc, op_method_name, client_err_except):
 
   https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html#parsing-error-responses-and-catching-exceptions-from-aws-services
   """
-  verb = op_method_name.split("_")[0]
-  err_dict = getattr(client_err_except, "response", {}).get("Error", {})
-  err_msg = err_dict.get("Message")
+  log_level = logging.ERROR
+  recoverable = False
 
-  log_level = logging.INFO
-  recoverable = True
+  if isinstance(misc_except, botocore.exceptions.ClientError):
+    verb = op_method_name.split("_")[0]
+    err_dict = getattr(misc_except, "response", {}).get("Error", {})
+    err_msg = err_dict.get("Message")
 
-  match (svc, err_dict.get("Code")):
+    match (svc, err_dict.get("Code")):
 
-    case ("cloudformation", "ValidationError") if (
-      "No updates are to be performed." == err_msg
-    ):
-      pass  # Recent, identical external update_stack
+      case ("cloudformation", "ValidationError") if (
+        "No updates are to be performed." == err_msg
+      ):
+        log_level = logging.INFO
+        recoverable = True
+        # Recent, identical external update_stack
 
-    case ("rds", "InvalidDBClusterStateFault") if (
-      ((verb == "start") and "is in available" in err_msg)
-      or f"is in {verb}" in err_msg
-    ):
-      pass
-      # start_db_cluster when "in available[ state]" or "in start[ing state]"
-      # stop__db_cluster when "in stop[ped state]"   or "in stop[ping state]"
+      case ("rds", "InvalidDBClusterStateFault") if (
+        ((verb == "start") and "is in available" in err_msg)
+        or f"is in {verb}" in err_msg
+      ):
+        log_level = logging.INFO
+        recoverable = True
+        # start_db_cluster when "in available[ state]" or "in start[ing state]"
+        # stop__db_cluster when "in stop[ped state]"   or "in stop[ping state]"
 
-    case ("rds", "InvalidDBInstanceState"):  # Fault suffix is missing here!
-      log_level = logging.ERROR
-      # Can't decide between idempotent start_db_instance / stop_db_instance
-      # or error, because message does not reveal the current, invalid state.
-
-    case _:
-      log_level = logging.ERROR
-      recoverable = False
+      case ("rds", "InvalidDBInstanceState"):  # Fault suffix is missing here!
+        recoverable = True
+        # Can't decide between idempotent start_db_instance / stop_db_instance
+        # or error, because message does not reveal the current, invalid state.
 
   return (log_level, recoverable)
 
@@ -702,14 +702,14 @@ def lambda_handler_do(event, context):  # pylint: disable=unused-argument
       op_kwargs = json.loads(msg["body"])
       op_method = getattr(svc_client, op_method_name)
       resp = op_method(**op_kwargs)
-    except botocore.exceptions.ClientError as client_err_except:
-      (log_level, recoverable) = assess_op_client_err(
-        svc, op_method_name, client_err_except
+    except Exception as misc_except:  # pylint: disable=broad-exception-caught
+      (log_level, recoverable) = assess_op_except(
+        svc, op_method_name, misc_except
       )
       op_log(
         event,
         entry_type="EXCEPTION",
-        entry_value=client_err_except,
+        entry_value=misc_except,
         log_level=log_level
       )
       if not recoverable:

--- a/lights_off_aws.py
+++ b/lights_off_aws.py
@@ -122,6 +122,45 @@ def op_log(
     log(entry_type, entry_value, log_level)
 
 
+def assess_op_except(svc, op_method_name, svc_client, misc_except):
+  """Take an operation and an exception, return log level and fatal flag
+  """
+  log_level = logging.ERROR
+  fatal = True
+
+  if svc == "cloudformation":
+    if isinstance(
+      misc_except, svc_client.exceptions.TokenAlreadyExistsException
+    ):
+      # Idempotent update_stack operation, not an error
+      log_level = logging.INFO
+      fatal = False
+
+  elif svc == "rds":
+    verb = op_method_name.split("_")[0]
+    misc_except_msg = str(misc_except)
+    if isinstance(
+      misc_except, svc_client.exceptions.InvalidDBInstanceStateFault
+    ):
+      # Idempotent database INSTANCE operations cannot be distinguished from
+      # permanent errors. Available exception is too general, because it does
+      # not name the invalid state. Log as an error, but a non-fatal one.
+      fatal = False
+    elif isinstance(
+      misc_except, svc_client.exceptions.InvalidDBClusterStateFault
+    ) and (
+      ((verb == "start") and "is in available" in misc_except_msg)
+      or f"is in {verb}" in misc_except_msg
+    ):
+      # Idempotent database CLUSTER operations: start_db_cluster when
+      # "in available[ state]" or "in start[ing state]", stop_db_cluster when
+      # "in stop[ped state]" or "in stop[ping state]"
+      log_level = logging.INFO
+      fatal = False
+
+  return (log_level, fatal)
+
+
 def tag_key_join(tag_key_words):
   """Take a tuple of strings, add a prefix, join, and return a tag key
   """
@@ -418,7 +457,10 @@ class AWSOpUpdateStack(AWSOp):
 
     # Use of final template instead of original makes this incompatible with
     # CloudFormation "transforms". describe_stacks does not return templates.
-    self.kwargs_add["UsePreviousTemplate"] = True
+    self.kwargs_add.update({
+      "UsePreviousTemplate": True,
+      "RetainExceptOnCreate": True,
+    })
 
     # Use previous parameter values, except for:
     #                          Param  Value
@@ -437,30 +479,40 @@ class AWSOpUpdateStack(AWSOp):
     op_kwargs_out = {}
     params_out = []
 
-    for param in rsrc.get("Parameters", []):
+    if rsrc.get("StackStatus") in (
+      "UPDATE_COMPLETE",
+      "CREATE_COMPLETE",
+    ):
+      for param in rsrc.get("Parameters", []):
+        param_key = param["ParameterKey"]
+        param_out = {
+          "ParameterKey": param_key,
+          "UsePreviousValue": True,
+        }
 
-      param_key = param["ParameterKey"]
-      param_out = {
-        "ParameterKey": param_key,
-        "UsePreviousValue": True,
-      }
+        if param_key == self.changing_param_key:
+          if param.get("ParameterValue") == self.changing_param_value_out:
+            break
 
-      if param_key == self.changing_param_key:
-        if param.get("ParameterValue") == self.changing_param_value_out:
-          break
+          # One time, if changing_param is present and not already up-to-date
+          param_out.update({
+            "UsePreviousValue": False,
+            "ParameterValue": self.changing_param_value_out,
+          })
+          op_kwargs_out = super().op_kwargs(rsrc, cycle_start_str)
+          op_kwargs_out.update({
+            "ClientRequestToken": f"{self.tag_key}-{cycle_start_str}",
+            "Parameters": params_out,  # Continue updating dict in-place
+          })
+          capabilities = rsrc.get("Capabilities")
+          if capabilities:
+            op_kwargs_out["Capabilities"] = capabilities
 
-        # Never, if changing_param is absent or up-to-date; once at most...
-        param_out.update({
-          "UsePreviousValue": False,
-          "ParameterValue": self.changing_param_value_out,
-        })
-        op_kwargs_out = super().op_kwargs(rsrc, cycle_start_str)
-        op_kwargs_out["Parameters"] = params_out  # Continue updating in-place
-        capabilities = rsrc.get("Capabilities")
-        if capabilities:
-          op_kwargs_out["Capabilities"] = capabilities
+        params_out.append(param_out)
 
-      params_out.append(param_out)
+    else:
+      log("ERROR", "STACK_STATUS_IRREGULAR", logging.ERROR)
+      log("AWS_RESPONSE_PART", rsrc, logging.ERROR)
 
     return op_kwargs_out
 
@@ -600,7 +652,10 @@ def lambda_handler_find(event, context):  # pylint: disable=unused-argument
   (cycle_start, cycle_cutoff) = cycle_start_end(
     datetime.datetime.now(datetime.timezone.utc)
   )
-  cycle_start_str = cycle_start.strftime("%Y-%m-%dT%H:%MZ")
+
+  # ISO 8601 basic, no puctuation (downstream requirement)
+  cycle_start_str = cycle_start.strftime("%Y%m%dT%H%MZ")
+
   cycle_cutoff_epoch_str = str(int(cycle_cutoff.timestamp()))
   sched_regexp = re.compile(
     cycle_start.strftime(SCHED_REGEXP_STRFTIME_FMT), re.VERBOSE
@@ -641,13 +696,23 @@ def lambda_handler_do(event, context):  # pylint: disable=unused-argument
 
     svc = msg_attr_str_decode(msg, "svc")
     op_method_name = msg_attr_str_decode(msg, "op_method_name")
+    svc_client = svc_client_get(svc)
     try:
       op_kwargs = json.loads(msg["body"])
-      op_method = getattr(svc_client_get(svc), op_method_name)
+      op_method = getattr(svc_client, op_method_name)
       resp = op_method(**op_kwargs)
-    except Exception as misc_except:
-      op_log(event, entry_type="EXCEPTION", entry_value=misc_except)
-      raise
+    except Exception as misc_except:  # pylint: disable=broad-exception-caught
+      (log_level, fatal) = assess_op_except(
+        svc, op_method_name, svc_client, misc_except
+      )
+      op_log(
+        event,
+        entry_type="EXCEPTION",
+        entry_value=misc_except,
+        log_level=log_level
+      )
+      if fatal:
+        raise
     if boto3_success(resp):
       op_log(event, resp=resp, log_level=logging.INFO)
     else:


### PR DESCRIPTION
- Handles exceptions for idempotent RDS and Aurora start/stop operations, making logs much quieter
- Supports idempotent CloudFormation stack updates by setting `ClientRequestToken`
- Changes the format of the `sched-time` tag on backups from ISO 8601 extended (with punctuation) to basic (without punctuation), because the value is also used in `ClientRequestToken` and the AWS API does not allow `:` there
- To prevent failed updates and rollbacks, logs an error and skips scheduled CloudFormation stack updates if stack status is other than `CREATE_COMPLETE` or `UPDATE_COMPLETE`
- Simplifies SQS send message logging