### PR TITLE
README: Stop RDS, Aurora databases longer than 7 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,8 @@ Jump to:
 |EC2:||||
 |[Instance](https://console.aws.amazon.com/ec2/home#Instances)|[&check;](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Stop_Start.html)|[&check;](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/hibernating-prerequisites.html)|&rarr; Image (AMI)|
 |[EBS Volume](https://console.aws.amazon.com/ec2/home#Volumes)|||&rarr; Snapshot|
-|RDS:||||
+|RDS and Aurora:||||
 |[Database Instance](https://console.aws.amazon.com/rds/home#databases:)|[&check;](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_StopInstance.html)||&rarr; Snapshot|
-|Aurora:||||
 |[Database Cluster](https://console.aws.amazon.com/rds/home#databases:)|[&check;](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-cluster-stop-start.html)||&rarr; Snapshot|
 
 - Whether a database operation is at the cluster or instance level depends on


### PR DESCRIPTION
- Adds sample schedules for different geographies, to start and stop databases once a week as a work-around for RDS and Aurora's 7-day limit.
- Links to AWS start/stop documentation for EC2 instances, RDS database instances, and Aurora database clusters.
- Links to a detailed technical article about idempotence and errors for EC2, RDS, Aurora, CloudFormation and AWS Backup.