### PR TITLE
Simplify error handling code

### DIFF
--- a/lights_off_aws.py
+++ b/lights_off_aws.py
@@ -330,7 +330,7 @@ class AWSRsrcType():  # pylint: disable=too-many-instance-attributes
 
       if op_tags_matched_count == 1:
         op = self.ops[op_tags_matched[0]]
-        op.queue(rsrc, cycle_start_str, cycle_cutoff_epoch_str)
+        op.msg_send_to_queue(rsrc, cycle_start_str, cycle_cutoff_epoch_str)
       elif op_tags_matched_count > 1:
         log("START", cycle_start_str, logging.ERROR)
         log(
@@ -388,7 +388,7 @@ class AWSOp():
     op_kwargs_out.update(self.kwargs_add)
     return op_kwargs_out
 
-  def queue(self, rsrc, cycle_start_str, cycle_cutoff_epoch_str):
+  def msg_send_to_queue(self, rsrc, cycle_start_str, cycle_cutoff_epoch_str):
     """Send 1 operation message to the SQS queue
     """
     op_kwargs = self.op_kwargs(rsrc, cycle_start_str)

--- a/lights_off_aws.py
+++ b/lights_off_aws.py
@@ -117,6 +117,7 @@ def assess_op_msg(op_msg):
       "increase DoLambdaFnMaximumConcurrency in CloudFormation"
     )
     result_type = "EXPIRED_OP"
+    raise_except = RuntimeError()
 
   return (result, result_type, raise_except)
 

--- a/lights_off_aws.py
+++ b/lights_off_aws.py
@@ -224,8 +224,7 @@ def svc_client_get(svc):
 # See rsrc_types_init() for usage examples.
 
 
-# pylint: disable=too-many-instance-attributes
-class AWSRsrcType():
+class AWSRsrcType():  # pylint: disable=too-many-instance-attributes
   """AWS resource type, with identification properties and various operations
   """
   members = {}

--- a/lights_off_aws.py
+++ b/lights_off_aws.py
@@ -100,7 +100,7 @@ def assess_op_msg(op_msg):
   """Take an operation queue message, return error message, type, exception
   """
   result = None
-  result_type = None
+  result_type = ""
   raise_except = None
 
   if msg_attr_str_decode(op_msg, "version") != QUEUE_MSG_FMT_VERSION:
@@ -407,7 +407,7 @@ class AWSOp():
       }
 
       result = None
-      result_type = None
+      result_type = ""
 
       log_level = logging.ERROR
 
@@ -688,7 +688,7 @@ def lambda_handler_do(event, context):  # pylint: disable=unused-argument
   """
   for op_msg in event.get("Records", []):  # 0 or 1 messages expected
     result = None
-    result_type = None
+    result_type = ""
     raise_except = None
 
     log_level = logging.ERROR

--- a/lights_off_aws.py
+++ b/lights_off_aws.py
@@ -416,7 +416,7 @@ class AWSOp():
         if QUEUE_MSG_BYTES_MAX < len(bytes(msg_body, "utf-8")):
           result = "Increase QueueMessageBytesMax in CloudFormation"
           result_type = "QUEUE_MSG_TOO_LONG"
-          # Continue to next message (likely to be shorter)
+          # Allow continue to next message (likely to be shorter)
 
         else:
           result = svc_client_get("sqs").send_message(**send_kwargs)
@@ -675,9 +675,13 @@ def lambda_handler_find(event, context):  # pylint: disable=unused-argument
   log("SCHED_REGEXP_VERBOSE", sched_regexp.pattern, logging.DEBUG)
   rsrc_types_init()
   for rsrc_type in AWSRsrcType.members.values():
-    rsrc_type.rsrcs_find(
-      sched_regexp, cycle_start_str, cycle_cutoff_epoch_str
-    )
+    try:
+      rsrc_type.rsrcs_find(
+        sched_regexp, cycle_start_str, cycle_cutoff_epoch_str
+      )
+    except Exception as misc_except:  # pylint: disable=broad-exception-caught
+      log("EXCEPTION", misc_except, logging.ERROR)
+      # Allow continue to next describe_ call (likely that permissions differ)
 
 # 5. "Do" Operations Lambda Function Handler #################################
 

--- a/lights_off_aws.py
+++ b/lights_off_aws.py
@@ -407,7 +407,6 @@ class AWSOp():
 
       result = None
       result_type = None
-      raise_except = None
 
       log_level = logging.ERROR
 
@@ -418,7 +417,6 @@ class AWSOp():
         if QUEUE_MSG_BYTES_MAX < len(bytes(msg_body, "utf-8")):
           result = "Increase QueueMessageBytesMax in CloudFormation"
           result_type = "QUEUE_MSG_TOO_LONG"
-          # Allow continue to next message (likely to be shorter)
 
         else:
           result = svc_client_get("sqs").send_message(**send_kwargs)
@@ -428,14 +426,10 @@ class AWSOp():
       except Exception as misc_except:  # pylint: disable=broad-exception-caught
         result = misc_except
         result_type = "EXCEPTION"
-        raise_except = misc_except
-        # Do not continue to next message (likely to fill log with same error)
 
       sqs_send_message_log(
         cycle_start_str, send_kwargs, result, result_type, log_level
       )
-      if raise_except:
-        raise raise_except
 
   def __str__(self):
     return " ".join([

--- a/lights_off_aws.py
+++ b/lights_off_aws.py
@@ -97,7 +97,7 @@ def op_log(event, result, result_type, log_level):
 
 
 def assess_op_msg(op_msg):
-  """Take an operation queue message, return error message and code for log
+  """Take an operation queue message, return error message and type, for log
   """
   result = None
   result_type = None


### PR DESCRIPTION
- Find function logs but does not raise `describe_` errors or SQS `send_message`-related errors. Processing continues in either case, which may result in repetition of similar error messages, but has a greater chance of salvaging work for the remaining resource types and/or resources.

- `STACK_STATUS_IRREGULAR` is now properly logged as an error code (`type`), and an explanatory message (`value`) is provided.

- Some names have been made more specific.

- A `result` (ex-`entry_value`), `result_type` (ex-`entry-type`), `raise_except` , `log_level` tuple covers different error scenarios:
  
  1. Error code and message, logged at `ERROR` level, such as
    `{"type": "WRONG_QUEUE_MSG_FMT", "value": "Unrecognized operation queue message format"}`
  2. Expected exception (does not require attention), logged at `INFO` level
  3. Exception that may require attention but does not stop further processing, logged at `ERROR` level
  4. Unexpected exception, logged and then raised so as to stop processing
  
  The choice between 2 and 3 can occur outside the `except` clause, with reference to `assess_` helper functions.
  
  Custom logging is crucial for 4. Contextual data that might have been logged at `INFO` level must definitely be logged at `ERROR` level. New structure avoids calls to same log helper function in both the `try` and `except` clauses.
  
  The order of `result_type` and `result` is reversed because within a `try` clause, a success type such as `AWS_RESPONSE` should not be set before result has been successfully set to the result of an AWS API call.