### PR TITLE
feat: control concurrency settings by var

### DIFF
--- a/terraform-multi/main.tf
+++ b/terraform-multi/main.tf
@@ -125,8 +125,8 @@ resource "aws_cloudformation_stack_set" "lights_off" {
   operation_preferences {
     region_order            = sort(keys(data.aws_region.lights_off_stackset))
     region_concurrency_type = "PARALLEL"
-    max_concurrent_count    = 2
-    failure_tolerance_count = 2
+    max_concurrent_count    = var.lights_off_multi_concurrency_count
+    failure_tolerance_count = var.lights_off_multi_failure_tolerance_count
   }
 
   auto_deployment {
@@ -159,8 +159,8 @@ resource "aws_cloudformation_stack_set_instance" "lights_off" {
   operation_preferences {
     region_order            = sort(keys(data.aws_region.lights_off_stackset))
     region_concurrency_type = "PARALLEL"
-    max_concurrent_count    = 2
-    failure_tolerance_count = 2
+    max_concurrent_count    = var.lights_off_multi_concurrency_count
+    failure_tolerance_count = var.lights_off_multi_failure_tolerance_count
   }
 
   stack_set_instance_region = each.value.region

--- a/terraform-multi/variables.tf
+++ b/terraform-multi/variables.tf
@@ -146,6 +146,20 @@ variable "lights_off_stackset_organizational_unit_ids" {
   }
 }
 
+variable "lights_off_multi_concurrency_count" {
+  type        = number
+  description = "Number of concurrent StackSet instance deployments to run in each region."
+
+  default = 2
+}
+
+variable "lights_off_multi_failure_tolerance_count" {
+  type        = number
+  description = "Number of concurrent StackSet instance deployment failures to allow in each region before stopping deployments in that region."
+
+  default = 2
+}
+
 variable "lights_off_stackset_regions" {
   type        = list(string)
   description = "List of region codes for the regions in which to create instances of the CloudFormation StackSet. The empty list causes the module to use lights_off_region . Initial deployment will proceed in alphabetical order by region code."


### PR DESCRIPTION
Current hardcoded concurrency settings can be bothersome for larger AWS organizations and multi-region deployments. Adds new vars to control concurrency while keeping the previous hardcoded values as defaults.